### PR TITLE
feat: show complete prompt context

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -164,7 +164,7 @@ Transcript scroll: PageUp / PageDown, mouse wheel, Ctrl+Home / Ctrl+End to top /
 - Missions: `/new` `/resume` `/name` `/mission`, `-c`
 - Token stats + refuse submit when last prompt ≥ window
 - CWD `AGENTS.md` / `CONTEXT.md` + `.agents/skills` summaries as a leading user message, snapshotted per user turn
-- Commands that exist: `/quit` `/q` `/help` `/new` `/resume` `/model` `/thinking` `/login` `/logout` `/name` `/mission` `/context`
+- Commands that exist: `/quit` `/q` `/help` `/new` `/resume` `/model` `/thinking` `/login` `/logout` `/name` `/mission` `/context`. `/context` opens a component summary of the live preamble and current history, with count and estimated-token breakdowns for user messages, assistant messages, tool calls, and tool results, plus a preamble + history total; `/context raw` shows their full contents, including tool calls and results. Both use a pager: PageUp/PageDown, j/k, wheel, and Ctrl+Home/End scroll, while Esc or q closes it
 - Lua 5.5 embed; user `~/.lunar/control/init.lua` returns `{ models, providers, defaults }`
 - Thinking levels: `/thinking off|low|medium|high`; Lua model value overrides provider default; Completions and Responses wire mappings; live level in footer
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -78,6 +78,10 @@ pub(crate) enum Mode {
         cursor: usize,
     },
     ApiKey,
+    Context {
+        text: String,
+        scroll: usize,
+    },
     Resume {
         items: Vec<mission::Meta>,
         cursor: usize,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -13,7 +13,7 @@ pub const COMMANDS: &[Command] = &[
     },
     Command {
         name: "context",
-        description: "files and skills sent every prompt",
+        description: "summarize context; /context raw shows contents",
     },
     Command {
         name: "help",

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,216 @@
+//! Model-visible context assembly and preview.
+
+use std::fmt::Write as _;
+
+use crate::app::{Message, Role};
+use crate::prompt;
+use crate::protocol::ChatMessage;
+
+/// Build the semantic message history sent to either model protocol.
+pub(crate) fn history(preamble: Option<&str>, messages: &[Message]) -> Vec<ChatMessage> {
+    let mut out = Vec::new();
+    if let Some(text) = preamble {
+        out.push(ChatMessage::User(text.to_string()));
+    }
+    out.extend(
+        messages
+            .iter()
+            .filter(|m| {
+                !m.text.is_empty() || matches!(m.role, Role::User) || !m.tool_calls.is_empty()
+            })
+            .map(|m| match m.role {
+                Role::User => ChatMessage::User(m.text.clone()),
+                Role::Assistant => ChatMessage::Assistant {
+                    content: m.text.clone(),
+                    tool_calls: m.tool_calls.clone(),
+                },
+                Role::Tool => ChatMessage::Tool {
+                    id: m.tool_id.clone(),
+                    content: m.text.clone(),
+                },
+            }),
+    );
+    out
+}
+
+/// Summarize the context known before the next user message.
+pub(crate) fn summary(messages: &[Message]) -> String {
+    let (mut out, preamble_tokens) = prompt::summary();
+    let mut users = 0;
+    let mut assistants = 0;
+    let mut tool_calls = 0;
+    let mut tool_results = 0;
+    let mut user_chars = 0;
+    let mut assistant_chars = 0;
+    let mut tool_call_chars = 0;
+    let mut tool_result_chars = 0;
+    for message in messages {
+        match message.role {
+            Role::User => {
+                users += 1;
+                user_chars += message.text.chars().count();
+            }
+            Role::Assistant => {
+                assistants +=
+                    usize::from(!message.text.is_empty() || !message.tool_calls.is_empty());
+                assistant_chars += message.text.chars().count();
+                tool_calls += message.tool_calls.len();
+                tool_call_chars += message
+                    .tool_calls
+                    .iter()
+                    .map(|call| call.arguments.chars().count())
+                    .sum::<usize>();
+            }
+            Role::Tool => {
+                tool_results += 1;
+                tool_result_chars += message.text.chars().count();
+            }
+        }
+    }
+    let user_tokens = user_chars.div_ceil(4);
+    let assistant_tokens = assistant_chars.div_ceil(4);
+    let tool_call_tokens = tool_call_chars.div_ceil(4);
+    let tool_result_tokens = tool_result_chars.div_ceil(4);
+    let total_tokens = user_tokens + assistant_tokens + tool_call_tokens + tool_result_tokens;
+    let _ = write!(
+        out,
+        "\n\nhistory  ~{total_tokens} tokens\n  user messages      {users}  ~{user_tokens} tokens\n  assistant messages {assistants}  ~{assistant_tokens} tokens\n  tool calls         {tool_calls}  ~{tool_call_tokens} tokens\n  tool results       {tool_results}  ~{tool_result_tokens} tokens\n\ntotal  ~{} tokens",
+        preamble_tokens + total_tokens
+    );
+    out
+}
+
+/// Display the complete context known before the next user message.
+pub(crate) fn raw(messages: &[Message]) -> String {
+    let preamble = prompt::preamble();
+    let history = history(preamble.as_deref(), messages);
+    format_history(history)
+}
+
+fn format_history(history: Vec<ChatMessage>) -> String {
+    if history.is_empty() {
+        return "no prompt context or mission history".into();
+    }
+
+    let mut out = String::from("next prompt context (next user message not included)");
+    for message in history {
+        match message {
+            ChatMessage::User(content) => {
+                let _ = write!(out, "\n\n[user]\n{content}");
+            }
+            ChatMessage::Assistant {
+                content,
+                tool_calls,
+            } => {
+                if !content.is_empty() {
+                    let _ = write!(out, "\n\n[assistant]\n{content}");
+                }
+                for call in tool_calls {
+                    let _ = write!(
+                        out,
+                        "\n\n[assistant tool call: {} · {}]\n{}",
+                        call.name, call.id, call.arguments
+                    );
+                }
+            }
+            ChatMessage::Tool { id, content } => {
+                let _ = write!(out, "\n\n[tool result: {id}]\n{content}");
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::Message;
+    use crate::protocol::ToolCall;
+
+    #[test]
+    fn summary_counts_history_components_without_contents() {
+        let mut assistant = Message::assistant();
+        assistant.text = "secret answer".into();
+        assistant.tool_calls.push(ToolCall {
+            id: "call-1".into(),
+            name: "read".into(),
+            arguments: "secret arguments".into(),
+        });
+        let messages = vec![
+            Message::user("secret question".into()),
+            assistant,
+            Message::tool("call-1".into(), "read".into(), "secret result".into()),
+        ];
+
+        let summary = summary(&messages);
+        assert!(summary.contains("history  ~"));
+        assert!(summary.contains("total  ~"));
+        assert!(summary.contains("user messages      1  ~4 tokens"));
+        assert!(summary.contains("assistant messages 1  ~4 tokens"));
+        assert!(summary.contains("tool calls         1  ~4 tokens"));
+        assert!(summary.contains("tool results       1  ~4 tokens"));
+        assert!(!summary.contains("secret question"));
+        assert!(!summary.contains("secret answer"));
+        assert!(!summary.contains("secret arguments"));
+        assert!(!summary.contains("secret result"));
+    }
+
+    #[test]
+    fn raw_shows_every_model_visible_field() {
+        let history = vec![
+            ChatMessage::User("instructions".into()),
+            ChatMessage::Assistant {
+                content: "checking".into(),
+                tool_calls: vec![ToolCall {
+                    id: "call-1".into(),
+                    name: "read".into(),
+                    arguments: r#"{"path":"CONTEXT.md"}"#.into(),
+                }],
+            },
+            ChatMessage::Tool {
+                id: "call-1".into(),
+                content: "contents".into(),
+            },
+        ];
+
+        let preview = format_history(history);
+        assert!(preview.contains("[user]\ninstructions"));
+        assert!(preview.contains("[assistant]\nchecking"));
+        assert!(preview.contains("[assistant tool call: read · call-1]"));
+        assert!(preview.contains(r#"{"path":"CONTEXT.md"}"#));
+        assert!(preview.contains("[tool result: call-1]\ncontents"));
+    }
+
+    #[test]
+    fn history_keeps_model_message_order_and_tool_data() {
+        let mut assistant = Message::assistant();
+        assistant.text = "checking".into();
+        assistant.tool_calls.push(ToolCall {
+            id: "call-1".into(),
+            name: "read".into(),
+            arguments: r#"{"path":"CONTEXT.md"}"#.into(),
+        });
+        let messages = vec![
+            Message::user("question".into()),
+            assistant,
+            Message::tool("call-1".into(), "read".into(), "contents".into()),
+        ];
+
+        let history = history(Some("instructions"), &messages);
+        assert_eq!(history.len(), 4);
+        assert!(matches!(&history[0], ChatMessage::User(text) if text == "instructions"));
+        assert!(matches!(&history[1], ChatMessage::User(text) if text == "question"));
+        assert!(matches!(
+            &history[2],
+            ChatMessage::Assistant { content, tool_calls }
+                if content == "checking"
+                    && tool_calls[0].id == "call-1"
+                    && tool_calls[0].name == "read"
+                    && tool_calls[0].arguments == r#"{"path":"CONTEXT.md"}"#
+        ));
+        assert!(matches!(
+            &history[3],
+            ChatMessage::Tool { id, content } if id == "call-1" && content == "contents"
+        ));
+    }
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -18,7 +18,6 @@ use crate::input::{
     history_down, history_up, insert_input, line_down, line_up, next_char, on_complete_key,
     on_search_key, prev_char, reset_history_navigation, start_search, word_left, word_right,
 };
-use crate::prompt;
 use crate::transcript::{jump_to_tail, on_mouse, page_delta, scroll_by, scroll_home};
 use crate::turn::{abort_turn, drain_stream, send_prompt};
 use crate::view::draw;
@@ -68,6 +67,7 @@ pub(crate) fn on_key(app: &mut App, key: KeyEvent) {
         Mode::LoginProvider { cursor } => on_login_provider_key(app, key, *cursor),
         Mode::LoginMethod { cursor } => on_login_method_key(app, key, *cursor),
         Mode::ApiKey => on_api_key(app, key),
+        Mode::Context { .. } => on_context_key(app, key),
         Mode::Thinking { cursor } => on_thinking_key(app, key, *cursor),
         Mode::Model { items, cursor } => {
             let len = items.len();
@@ -121,6 +121,30 @@ fn on_login_method_key(app: &mut App, key: KeyEvent, cursor: usize) {
             app.input.clear();
             app.cursor = 0;
         }
+        _ => {}
+    }
+}
+
+fn on_context_key(app: &mut App, key: KeyEvent) {
+    let page = app.transcript_h.saturating_sub(1).max(1) as usize;
+    let Some((text, scroll)) = (match &mut app.mode {
+        Mode::Context { text, scroll } => Some((text, scroll)),
+        _ => None,
+    }) else {
+        return;
+    };
+    let width = app.transcript_w.max(1) as usize;
+    let max = crate::view::context_lines(text, width)
+        .len()
+        .saturating_sub(app.transcript_h as usize);
+    match (key.modifiers, key.code) {
+        (_, KeyCode::Esc | KeyCode::Char('q')) => app.mode = Mode::Chat,
+        (_, KeyCode::PageUp) => *scroll = scroll.saturating_sub(page),
+        (_, KeyCode::PageDown) => *scroll = scroll.saturating_add(page).min(max),
+        (KeyModifiers::CONTROL, KeyCode::Home) => *scroll = 0,
+        (KeyModifiers::CONTROL, KeyCode::End) => *scroll = max,
+        (_, KeyCode::Up | KeyCode::Char('k')) => *scroll = scroll.saturating_sub(1),
+        (_, KeyCode::Down | KeyCode::Char('j')) => *scroll = scroll.saturating_add(1).min(max),
         _ => {}
     }
 }
@@ -380,7 +404,14 @@ pub(crate) fn submit(app: &mut App) {
             }
         }
         "/mission" => show_mission(app),
-        "/context" => app.notice = Some(prompt::summary()),
+        "/context" | "/context raw" => {
+            let text = if line == "/context raw" {
+                crate::context::raw(&app.messages)
+            } else {
+                crate::context::summary(&app.messages)
+            };
+            app.mode = Mode::Context { text, scroll: 0 };
+        }
         cmd if let Some(name) = cmd.strip_prefix("/name ") => name_mission(app, name),
         cmd if let Some(prefix) = cmd.strip_prefix("/resume ") => resume_prefix(app, prefix),
         cmd if cmd.starts_with('/') => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod app;
 mod auth;
 mod cli;
 mod commands;
+mod context;
 mod debug;
 mod event;
 mod history;
@@ -164,6 +165,19 @@ mod tests {
 
     fn key(modifiers: KeyModifiers, code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, modifiers)
+    }
+
+    #[test]
+    fn context_pager_closes_with_escape_or_q() {
+        for code in [KeyCode::Esc, KeyCode::Char('q')] {
+            let mut app = test_app();
+            app.mode = Mode::Context {
+                text: "context".into(),
+                scroll: 0,
+            };
+            on_key(&mut app, key(KeyModifiers::NONE, code));
+            assert!(matches!(app.mode, Mode::Chat));
+        }
     }
 
     #[test]

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -40,46 +40,39 @@ pub fn budget_warning() -> Option<String> {
     }
 }
 
-/// Live listing of CWD files and skill summaries sent on every request.
-pub fn summary() -> String {
+pub fn summary() -> (String, usize) {
     match std::env::current_dir() {
         Ok(cwd) => summary_in(&cwd),
-        Err(_) => "no cwd".into(),
+        Err(_) => ("no cwd".into(), 0),
     }
 }
 
-fn summary_in(cwd: &Path) -> String {
+fn summary_in(cwd: &Path) -> (String, usize) {
     let files = load_files(cwd);
     let skills = load_skills(cwd);
     if files.is_empty() && skills.is_empty() {
-        return "no prompt context".into();
+        return ("no preamble".into(), 0);
     }
     let text = render(&files, &skills);
     let tokens = estimate_tokens(&text);
     let budget = budget_tokens();
-    let mut out = format!("prompt context  ~{tokens} / {budget} tokens");
+    let mut out = format!("preamble  ~{tokens} / {budget} tokens");
     if !files.is_empty() {
-        out.push_str("\nfiles");
+        out.push_str("\n  files");
         for (name, body) in &files {
-            let n = body.lines().count();
-            let _ = write!(out, "\n  {name}  {n} lines");
+            let _ = write!(out, "\n    {name}  {} lines", body.lines().count());
         }
     }
     if !skills.is_empty() {
-        out.push_str("\nskills");
+        out.push_str("\n  skill summaries");
         for skill in &skills {
-            if skill.description.is_empty() {
-                let _ = write!(out, "\n  {}  (`{}`)", skill.name, skill.path);
-            } else {
-                let _ = write!(
-                    out,
-                    "\n  {}: {}  (`{}`)",
-                    skill.name, skill.description, skill.path
-                );
+            let _ = write!(out, "\n    {}  (`{}`)", skill.name, skill.path);
+            if !skill.description.is_empty() {
+                let _ = write!(out, "\n      {}", skill.description);
             }
         }
     }
-    out
+    (out, tokens as usize)
 }
 
 fn load(cwd: &Path) -> Option<Loaded> {
@@ -290,6 +283,24 @@ mod tests {
     }
 
     #[test]
+    fn summary_nests_skill_description_under_name() {
+        let dir = scratch();
+        let skill = dir.join(".agents").join("skills").join("review");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: review\ndescription: Review a diff.\n---\n",
+        )
+        .unwrap();
+
+        let (summary, _) = summary_in(&dir);
+        assert!(
+            summary
+                .contains("    review  (`.agents/skills/review/SKILL.md`)\n      Review a diff.")
+        );
+    }
+
+    #[test]
     fn folded_description() {
         let (name, desc) = parse_frontmatter(
             "---\nname: ship\ndescription: >\n  Cut a release.\n  Tag it.\n---\n",
@@ -307,33 +318,5 @@ mod tests {
         let text = load(&dir).unwrap().text;
         assert!(text.contains("- notes (`.agents/skills/notes/SKILL.md`)"));
         assert!(!text.contains("just a body"));
-    }
-
-    #[test]
-    fn summary_lists_files_and_skills() {
-        let dir = scratch();
-        fs::write(dir.join("AGENTS.md"), "be brief\n").unwrap();
-        let skill = dir.join(".agents").join("skills").join("review");
-        fs::create_dir_all(&skill).unwrap();
-        fs::write(
-            skill.join("SKILL.md"),
-            "---\nname: review\ndescription: Review a diff.\n---\n\nbody\n",
-        )
-        .unwrap();
-        let text = summary_in(&dir);
-        assert!(text.starts_with("prompt context  ~"));
-        assert!(text.contains("files"));
-        assert!(text.contains("AGENTS.md  1 lines"));
-        assert!(!text.contains("CONTEXT.md"));
-        assert!(text.contains("skills"));
-        assert!(text.contains("review: Review a diff."));
-        assert!(text.contains(".agents/skills/review/SKILL.md"));
-        assert!(!text.contains("body"));
-    }
-
-    #[test]
-    fn summary_empty_cwd() {
-        let dir = scratch();
-        assert_eq!(summary_in(&dir), "no prompt context");
     }
 }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -59,7 +59,7 @@ pub(crate) fn painted_lines(app: &mut App, width: usize) -> Vec<Line<'static>> {
         if !lines.is_empty() {
             lines.push(Line::from(""));
         }
-        lines.extend(notice_lines(notice));
+        lines.extend(notice_lines(notice, width));
     }
     lines
 }
@@ -103,6 +103,14 @@ pub(crate) fn paint_slice(
 
 pub(crate) const WHEEL_LINES: usize = 3;
 
+fn has_content(app: &App) -> bool {
+    !app.messages.is_empty()
+        || app
+            .notice
+            .as_deref()
+            .is_some_and(|notice| notice.contains('\n'))
+}
+
 pub(crate) fn page_delta(app: &App) -> isize {
     app.transcript_h.saturating_sub(1).max(1) as isize
 }
@@ -112,7 +120,7 @@ pub(crate) fn jump_to_tail(app: &mut App) {
 }
 
 pub(crate) fn scroll_home(app: &mut App) {
-    if !matches!(app.mode, Mode::Chat) || app.messages.is_empty() {
+    if !matches!(app.mode, Mode::Chat) || !has_content(app) {
         return;
     }
     app.scroll = 0;
@@ -120,7 +128,7 @@ pub(crate) fn scroll_home(app: &mut App) {
 }
 
 pub(crate) fn scroll_by(app: &mut App, delta: isize) {
-    if !matches!(app.mode, Mode::Chat) || app.messages.is_empty() {
+    if !matches!(app.mode, Mode::Chat) || !has_content(app) {
         return;
     }
     let height = app.transcript_h as usize;
@@ -144,6 +152,18 @@ pub(crate) fn scroll_by(app: &mut App, delta: isize) {
 }
 
 pub(crate) fn on_mouse(app: &mut App, mouse: MouseEvent) {
+    if let Mode::Context { text, scroll } = &mut app.mode {
+        let width = app.transcript_w.max(1) as usize;
+        let max = crate::view::context_lines(text, width)
+            .len()
+            .saturating_sub(app.transcript_h as usize);
+        match mouse.kind {
+            MouseEventKind::ScrollUp => *scroll = scroll.saturating_sub(WHEEL_LINES),
+            MouseEventKind::ScrollDown => *scroll = scroll.saturating_add(WHEEL_LINES).min(max),
+            _ => {}
+        }
+        return;
+    }
     match mouse.kind {
         MouseEventKind::ScrollUp => scroll_by(app, -(WHEEL_LINES as isize)),
         MouseEventKind::ScrollDown => scroll_by(app, WHEEL_LINES as isize),

--- a/src/turn.rs
+++ b/src/turn.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, TryRecvError};
 
 use crate::app::{App, Message, Role};
-use crate::protocol::{self, ChatMessage, Config, StreamEvent, ToolCall, ToolResult};
+use crate::protocol::{self, Config, StreamEvent, ToolCall, ToolResult};
 use crate::transcript::jump_to_tail;
 use crate::{mission, prompt, tools};
 
@@ -301,35 +301,9 @@ pub(crate) fn continue_turn(app: &mut App) {
         return;
     };
     app.messages.push(Message::assistant());
-    let history = api_history(app.preamble.as_deref(), &app.messages);
+    let history = crate::context::history(app.preamble.as_deref(), &app.messages);
     let (tx, rx) = mpsc::channel();
     app.stream_rx = Some(rx);
     let cache_key = app.mission.as_ref().map(|m| m.id.clone());
     std::thread::spawn(move || protocol::stream(cfg, history, cancel, tx, cache_key));
-}
-
-pub(crate) fn api_history(preamble: Option<&str>, messages: &[Message]) -> Vec<ChatMessage> {
-    let mut out = Vec::new();
-    if let Some(text) = preamble {
-        out.push(ChatMessage::User(text.to_string()));
-    }
-    out.extend(
-        messages
-            .iter()
-            .filter(|m| {
-                !m.text.is_empty() || matches!(m.role, Role::User) || !m.tool_calls.is_empty()
-            })
-            .map(|m| match m.role {
-                Role::User => ChatMessage::User(m.text.clone()),
-                Role::Assistant => ChatMessage::Assistant {
-                    content: m.text.clone(),
-                    tool_calls: m.tool_calls.clone(),
-                },
-                Role::Tool => ChatMessage::Tool {
-                    id: m.tool_id.clone(),
-                    content: m.text.clone(),
-                },
-            }),
-    );
-    out
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -184,6 +184,10 @@ pub(crate) fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
 }
 
 pub(crate) fn draw_messages(frame: &mut Frame, area: Rect, app: &mut App) {
+    if let Mode::Context { text, scroll } = &app.mode {
+        draw_context(frame, area, text, *scroll);
+        return;
+    }
     if let Mode::Resume {
         items,
         cursor,
@@ -193,11 +197,12 @@ pub(crate) fn draw_messages(frame: &mut Frame, area: Rect, app: &mut App) {
         draw_resume(frame, area, items, *cursor, title);
         return;
     }
-    if app.messages.is_empty() {
-        if app.notice.as_deref().is_some_and(|n| n.contains('\n')) {
-            draw_notice(frame, area, app.notice.as_deref().unwrap());
-            return;
-        }
+    if app.messages.is_empty()
+        && !app
+            .notice
+            .as_deref()
+            .is_some_and(|notice| notice.contains('\n'))
+    {
         draw_splash(frame, area, app);
         return;
     }
@@ -215,22 +220,29 @@ pub(crate) fn draw_messages(frame: &mut Frame, area: Rect, app: &mut App) {
     frame.render_widget(Paragraph::new(lines[start..end].to_vec()), area);
 }
 
-pub(crate) fn notice_lines(notice: &str) -> Vec<Line<'static>> {
-    notice
-        .lines()
-        .map(|line| {
-            Line::from(Span::styled(
-                line.to_string(),
-                Style::default().fg(splash::GOLD),
-            ))
-        })
-        .collect()
+pub(crate) fn context_lines(text: &str, width: usize) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from(Span::styled(
+        "context  page up/down · j/k · esc/q close",
+        Style::default().fg(splash::ASH),
+    ))];
+    lines.extend(notice_lines(text, width));
+    lines
 }
 
-pub(crate) fn draw_notice(frame: &mut Frame, area: Rect, notice: &str) {
-    let lines = notice_lines(notice);
-    let skip = lines.len().saturating_sub(area.height as usize);
-    frame.render_widget(Paragraph::new(lines[skip..].to_vec()), area);
+fn draw_context(frame: &mut Frame, area: Rect, text: &str, scroll: usize) {
+    let lines = context_lines(text, area.width.max(1) as usize);
+    let max = lines.len().saturating_sub(area.height as usize);
+    let start = scroll.min(max);
+    let end = (start + area.height as usize).min(lines.len());
+    frame.render_widget(Paragraph::new(lines[start..end].to_vec()), area);
+}
+
+pub(crate) fn notice_lines(notice: &str, width: usize) -> Vec<Line<'static>> {
+    notice
+        .lines()
+        .flat_map(|line| char_wrap(line, width.max(1)))
+        .map(|line| Line::from(Span::styled(line, Style::default().fg(splash::GOLD))))
+        .collect()
 }
 
 pub(crate) fn draw_model(frame: &mut Frame, area: Rect, items: &[lua::ModelChoice], cursor: usize) {


### PR DESCRIPTION
## Summary

- build model history through one shared context assembler
- make `/context` show preamble and history token summaries, with `/context raw` for full contents
- present both context views in a scrollable pager closed with Esc or q

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (141 passed)

🤖 Developed with [Lunar](https://github.com/gszr/lunar) 🌘
