### PR TITLE
fix: show all help commands

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -111,6 +111,15 @@ pub fn apply(name: &str) -> String {
     format!("/{name} ")
 }
 
+pub fn help() -> String {
+    let commands = COMMANDS
+        .iter()
+        .map(|command| format!("/{}", command.name))
+        .collect::<Vec<_>>()
+        .join("  ");
+    format!("{commands}\n\ntab cycle    shift+enter / ctrl+j newline    esc abort    ctrl+c quits")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -157,6 +166,17 @@ mod tests {
         let (start, view) = visible(&all, all.len() - 1);
         assert_eq!(start, all.len() - MAX_VISIBLE);
         assert_eq!(view.last().unwrap().name, all.last().unwrap().name);
+    }
+
+    #[test]
+    fn help_lists_every_command() {
+        let help = help();
+        for command in COMMANDS {
+            assert!(
+                help.split_whitespace()
+                    .any(|word| word == format!("/{}", command.name))
+            );
+        }
     }
 
     #[test]

--- a/src/event.rs
+++ b/src/event.rs
@@ -374,12 +374,7 @@ pub(crate) fn submit(app: &mut App) {
     reset_history_navigation(app);
     match line.as_str() {
         "/quit" | "/q" => app.quit = true,
-        "/help" => {
-            app.notice = Some(
-                "/quit /new /resume /model /thinking /config /login /logout /name /mission /context /help    tab cycle    shift+enter / ctrl+j newline    esc abort    ctrl+c quits"
-                    .into(),
-            );
-        }
+        "/help" => app.notice = Some(crate::commands::help()),
         "/config" => edit_config(app),
         "/new" => new_mission(app),
         "/login" => open_login(app),

--- a/src/view.rs
+++ b/src/view.rs
@@ -319,8 +319,9 @@ pub(crate) fn draw_splash(frame: &mut Frame, area: Rect, app: &App) {
         Style::default().fg(splash::ASH),
     ));
     let notice = app.notice.as_deref().unwrap_or("");
-    let extra = 4 + u16::from(!notice.is_empty());
-    let block_h = art_h.saturating_add(extra);
+    let notice_lines = notice_lines(notice, area.width.max(1) as usize);
+    let extra = 4usize.saturating_add(notice_lines.len());
+    let block_h = art_h.saturating_add(extra.min(u16::MAX as usize) as u16);
     let art_w = splash::width();
     let splash_area = Rect {
         x: area.x + area.width.saturating_sub(art_w) / 2,
@@ -334,9 +335,7 @@ pub(crate) fn draw_splash(frame: &mut Frame, area: Rect, app: &App) {
     lines.push(title.centered());
     lines.push(tag.centered());
     lines.push(tag2.centered());
-    if !notice.is_empty() {
-        lines.push(Line::from(Span::styled(notice, Style::default().fg(splash::GOLD))).centered());
-    }
+    lines.extend(notice_lines.into_iter().map(Line::centered));
     frame.render_widget(
         Paragraph::new(lines).alignment(Alignment::Left),
         splash_area,


### PR DESCRIPTION
## Summary
- generate `/help` from the command registry
- wrap multiline notices on the empty-mission splash
- test that help includes every registered command

## Checks
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`