### PR TITLE
feat: clarify token usage stats

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -145,7 +145,7 @@ Top to bottom:
    - Assistant: terminal-friendly CommonMark (gold headings, emphasis, inline/fenced code, valid fenced `json` pretty-printed, links with visible destinations, lists, blockquotes, rules). Tables use aligned Unicode borders and wrap cells to fit the transcript. Images render alt text plus URL
 3. **Working** — `⠋ Thinking...` while the model streams; `⠋ Running tools...` while tools run
 4. **Editor** — top **and** bottom rules, char-wrap, grows/shrinks (max 8 lines), real cursor
-5. **Footer (2 lines)** — cwd; then `↑in ↓out R W pct/window` left and `(provider) model • off` right
+5. **Footer (2 lines)** — cwd; then cumulative `↑total (Uuncached Rread Wwrite) ↓output` and latest `ctx tokens/window (pct)` left, `(provider) model • off` right. The cache split appears only when cache activity is reported; zero `R`/`W` components are omitted
 
 Readline: Ctrl+W / Alt+Backspace word-kill, Ctrl+U/K, Ctrl+A/E, arrows, Alt+B/F, Delete. Enter sends. Shift+Enter / Ctrl+J insert a newline. **Ctrl+C quits** (not clear). Esc aborts a turn or clears the editor.
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,23 @@ Type a prompt and press Enter. Run `/help` to see the available commands. Use `/
 
 Lunar includes `AGENTS.md`, `CONTEXT.md`, and summaries from `.agents/skills/*/SKILL.md` in its context.
 
+## Token usage
+
+The footer separates cumulative mission traffic from the latest request's context occupancy:
+
+```text
+↑2.1M (U30k R2.0M W100k) ↓8.5k  ctx 150k/1.0M (15.0%)
+```
+
+- `↑` is total input processed across the mission: `U + R + W`
+- `U` is ordinary input, neither read from nor written to the prompt cache
+- `R` is input read from the prompt cache
+- `W` is input written to the prompt cache
+- `↓` is generated output across the mission
+- `ctx` is the latest request's input relative to the model's context window
+
+These are provider-reported token statistics, not billing estimates. Lunar uses the same accounting for API keys and subscriptions, and omits cache components the provider reports as zero or does not report. Reopening a mission restores the cumulative totals and latest request size from its JSONL transcript; the context-window denominator comes from the current model configuration.
+
 Optional skills live in [`skills/`](skills/) and are not enabled by default. To enable Lunar attribution on pull requests and issues for a project:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Lunar includes `AGENTS.md`, `CONTEXT.md`, and summaries from `.agents/skills/*/S
 
 ## Token usage
 
-The footer separates cumulative mission traffic from the latest request's context occupancy:
+Some of Lunar's goals are transparency and token efficiency. Token accounting can be confusing, and most harnesses do little to explain what their numbers mean. Lunar separates cumulative mission traffic from current context occupancy, and breaks input down into ordinary, cache-read, and cache-write tokens. This makes it clear how much work the model has processed over the mission and how much of its context window the latest request occupies.
 
 ```text
 ↑2.1M (U30k R2.0M W100k) ↓8.5k  ctx 150k/1.0M (15.0%)

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ mod tests {
     use crate::transcript::painted_lines;
     use crate::transcript::{jump_to_tail, on_mouse};
     use crate::turn::{abort_turn, run_tools_parallel, skipped_truncated};
-    use crate::view::{char_wrap, cursor_xy, working_text};
+    use crate::view::{char_wrap, cursor_xy, stats_line, working_text};
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::crossterm::event::{MouseEvent, MouseEventKind};
     use std::sync::atomic::AtomicBool;
@@ -251,6 +251,37 @@ mod tests {
         assert_eq!(app.usage.cache_write, 7);
         assert_eq!(app.last_prompt, 52);
         std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn stats_show_total_input_split_and_current_context() {
+        let mut app = configured_app();
+        app.config.as_mut().unwrap().window = Some(1_000_000);
+        app.usage = Usage {
+            input: 30_000,
+            output: 8_500,
+            cache_read: 2_000_000,
+            cache_write: 100_000,
+        };
+        app.last_prompt = 150_000;
+
+        assert_eq!(
+            stats_line(&app),
+            "↑2.1M (U30k R2.0M W100k) ↓8.5k ctx 150k/1.0M (15.0%)"
+        );
+    }
+
+    #[test]
+    fn stats_omit_unreported_cache_components() {
+        let mut app = configured_app();
+        app.usage = Usage {
+            input: 30_000,
+            output: 0,
+            cache_read: 2_000_000,
+            cache_write: 0,
+        };
+
+        assert_eq!(stats_line(&app), "↑2.0M (U30k R2.0M)");
     }
 
     #[test]

--- a/src/view.rs
+++ b/src/view.rs
@@ -620,24 +620,34 @@ pub(crate) fn draw_footer(frame: &mut Frame, area: Rect, app: &App) {
 
 pub(crate) fn stats_line(app: &App) -> String {
     let mut parts = Vec::new();
-    if app.usage.input > 0 {
-        parts.push(format!("↑{}", format_tokens(app.usage.input)));
+    let input = app.usage.prompt();
+    if input > 0 {
+        let mut input = format!("↑{}", format_tokens(input));
+        if app.usage.cache_read > 0 || app.usage.cache_write > 0 {
+            let mut split = vec![format!("U{}", format_tokens(app.usage.input))];
+            if app.usage.cache_read > 0 {
+                split.push(format!("R{}", format_tokens(app.usage.cache_read)));
+            }
+            if app.usage.cache_write > 0 {
+                split.push(format!("W{}", format_tokens(app.usage.cache_write)));
+            }
+            input.push_str(&format!(" ({})", split.join(" ")));
+        }
+        parts.push(input);
     }
     if app.usage.output > 0 {
         parts.push(format!("↓{}", format_tokens(app.usage.output)));
-    }
-    if app.usage.cache_read > 0 {
-        parts.push(format!("R{}", format_tokens(app.usage.cache_read)));
-    }
-    if app.usage.cache_write > 0 {
-        parts.push(format!("W{}", format_tokens(app.usage.cache_write)));
     }
     if let Some(window) = app.config.as_ref().and_then(Config::context_window)
         && window > 0
         && app.last_prompt > 0
     {
         let pct = (f64::from(app.last_prompt) / f64::from(window)) * 100.0;
-        parts.push(format!("{pct:.1}%/{}", format_tokens(window)));
+        parts.push(format!(
+            "ctx {}/{} ({pct:.1}%)",
+            format_tokens(app.last_prompt),
+            format_tokens(window)
+        ));
     }
     parts.join(" ")
 }


### PR DESCRIPTION
## Summary

- show cumulative total input as `U + R + W`
- group the reported uncached, cache-read, and cache-write split under total input
- label the latest request's context occupancy separately from cumulative mission usage
- preserve the existing capability-driven behavior by omitting zero cache components

Example:

```text
↑2.1M (U30k R2.0M W100k) ↓8.5k ctx 150k/1.0M (15.0%)
```

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (145 passed)
