### PR TITLE
feat: load global agent context

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,7 +26,7 @@ You open `lunar` and talk. The binary does not dictate workflow (no MCP, sub-age
 | Lua guest API | `init.lua` returns one table containing optional `models`, `providers`, and `defaults` tables. The registrar form does not exist. **No `lunar.on`** (hook bus is not v0) |
 | Model catalog | Top-level `models`: alias → `{ id, window?, api?, thinking? }`. `id` is the wire string; alias is a Lua name. Provider `models` is an ordered list: string = ref to a global alias, table = local `{ id, window?, api?, thinking? }`. Missing alias = notice, skip that entry. Missing `id`, unknown `api`, or unknown `thinking` = notice, skip that entry. `thinking` is `off` · `low` · `medium` · `high`; a model value overrides its provider default. Omitted values resolve to `off`. Omitted `api` is Completions |
 | Live model | Top-level `defaults = { provider, model }`. `provider` is a providers key; `model` matches that list as alias then wire `id`. Unknown provider or model is an error: notice, glass opens, cannot send. Omitted defaults = no live Config; the catalog remains available in `/model`. Partial defaults (only one field) = present and invalid. The selected provider must have `base_url_cmd` or `base_url` unless `key_in = "auth"` and `auth_provider` is `xai` or `openai` (then `https://api.x.ai/v1` or `https://chatgpt.com/backend-api`). `key_in = "none"` requires an explicit `base_url`; HTTP and HTTPS are accepted. Plus `key_cmd` or `key_name` (`key_in = "env"`), or `auth_provider` (`key_in = "auth"`); missing the applicable source = notice, cannot send. `base_url_cmd` takes precedence over `base_url`, which takes precedence over an auth default. Live `api` `"messages"` is resolve-time refuse: notice, cannot send, entry stays in `/model`. Completions and Responses send. Live Config carries optional `auth_provider` from Lua `key_in = "auth"`. `"openai"` means Codex Responses + JWT account header; Completions on that auth is refuse. Do not sniff `base_url`. Model `window` if set, else the Grok-id guess. Footer provider is the providers key |
-| Prompt conventions | CWD `AGENTS.md` + `CONTEXT.md` in full. Skill *summaries* from `.agents/skills/*/SKILL.md`. Optional bundled skills live in `skills/` and are installed manually per project; none are enabled by default. `~/.agents/skills` later |
+| Prompt conventions | Rules come from CWD `AGENTS.md`, falling back to `~/.agents/AGENTS.md`; project rules replace global rules. CWD `CONTEXT.md` is included in full. Skill *summaries* merge from `~/.agents/skills/*/SKILL.md` and `.agents/skills/*/SKILL.md`; project skills replace global skills with the same directory name. Optional bundled skills live in `skills/` and are installed manually; none are enabled by default. |
 | System prompt | None. Context is a leading user message, snapshotted at each user submit, held for the tool loop, not persisted |
 | v0 goal | Daily driver for one user, not ecosystem parity |
 | Model protocol | Completions, Responses, and Messages. Selected by model `api`: `"completions"` · `"responses"` · `"messages"`. Case-sensitive, no aliases. Omitted `api` is Completions. Completions and Responses send. Responses stays `store: false`, requests an automatic reasoning summary for the thinking preview, and replays the full converted history each round. When a mission exists, Responses also sends `prompt_cache_key` (mission id, 64 chars max) and Pi affinity headers `session_id` / `x-client-request-id`. No `previous_response_id`. ChatGPT Plus (`auth_provider = "openai"`) is Responses-only: POST `{base_url}/codex/responses` (not `{base_url}/responses`), plus `chatgpt-account-id` decoded from the access JWT at send and refresh (`https://api.openai.com/auth` → `chatgpt_account_id`; missing or empty = notice, cannot send) and `originator: lunar`. No extra `auth.json` field. Completions on that auth is resolve-time refuse. No websocket and no zstd this slice. Messages is not implemented |
@@ -163,14 +163,14 @@ Transcript scroll: PageUp / PageDown, mouse wheel, Ctrl+Home / Ctrl+End to top /
 - Four tools + continue-after-tools (50-round cap; submit `continue` to proceed). Tools in one round run in parallel. Results cap 50KB or 2000 lines; truncated bash output is saved under `~/.lunar/recorder/tool-output/`. Truncated completions do not run tool calls
 - Missions: `/new` `/resume` `/name` `/mission`, `-c`
 - Token stats + refuse submit when last prompt ≥ window
-- CWD `AGENTS.md` / `CONTEXT.md` + `.agents/skills` summaries as a leading user message, snapshotted per user turn
+- Global/project `AGENTS.md`, CWD `CONTEXT.md`, and merged global/project skill summaries as a leading user message, snapshotted per user turn
 - Commands that exist: `/quit` `/q` `/help` `/new` `/resume` `/model` `/thinking` `/login` `/logout` `/name` `/mission` `/context`. `/context` opens a component summary of the live preamble and current history, with count and estimated-token breakdowns for user messages, assistant messages, tool calls, and tool results, plus a preamble + history total; `/context raw` shows their full contents, including tool calls and results. Both use a pager: PageUp/PageDown, j/k, wheel, and Ctrl+Home/End scroll, while Esc or q closes it
 - Lua 5.5 embed; user `~/.lunar/control/init.lua` returns `{ models, providers, defaults }`
 - Thinking levels: `/thinking off|low|medium|high`; Lua model value overrides provider default; Completions and Responses wire mappings; live level in footer
 
 **Not shipped (still v0 intent)**
 
-- Walk-up discovery, `~/.agents/skills`, skill bodies (only summaries ship)
+- Walk-up discovery, skill bodies (only summaries ship)
 - `/reload` `/trust`
 - Messages API (catalog accepts `api`; Completions and Responses send)
 - Cost in the footer, git branch, `$` prices
@@ -190,7 +190,7 @@ Package manager, print/RPC/SDK, Pi session compatibility, provider zoo, themes, 
 
 1. Messages, if you actually use a Messages-only id
 2. Dumb `/compact` after the window hurts
-3. Walk-up context + `~/.agents/skills`
+3. Walk-up context
 
 ## Layout in the repo
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ lunar
 
 Type a prompt and press Enter. Run `/help` to see the available commands. Use `/config` to edit and reload `init.lua`, `lunar -c` to continue the latest mission for the current directory, or `lunar -m` to open the mission log (`lunar -m <mission>` resumes a filename or label). Passing a date such as `lunar -m 2026-08-19` opens that day's mission log.
 
-Lunar includes `AGENTS.md`, `CONTEXT.md`, and summaries from `.agents/skills/*/SKILL.md` in its context.
+Lunar includes project `AGENTS.md` (or global `~/.agents/AGENTS.md`), project `CONTEXT.md`, and merged skill summaries from `~/.agents/skills` and `.agents/skills`. Project skills override global skills with the same directory name.
 
 ## Token usage
 

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,14 +1,15 @@
-//! CWD context files and skill summaries. Not a system prompt.
+//! Global and CWD context files and skill summaries. Not a system prompt.
 //!
 //! Loaded from disk at the start of each user turn so edits apply without
 //! /reload, then held stable across tool rounds for prefix cache.
 
+use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const DEFAULT_BUDGET: u32 = 16_000;
-const CONTEXT_FILES: &[&str] = &["AGENTS.md", "CONTEXT.md"];
+const CONTEXT_FILE: &str = "CONTEXT.md";
 
 struct Skill {
     name: String,
@@ -23,12 +24,12 @@ struct Loaded {
 
 pub fn preamble() -> Option<String> {
     let cwd = std::env::current_dir().ok()?;
-    load(&cwd).map(|loaded| loaded.text)
+    load(&cwd, global_agents().as_deref()).map(|loaded| loaded.text)
 }
 
 pub fn budget_warning() -> Option<String> {
     let cwd = std::env::current_dir().ok()?;
-    let loaded = load(&cwd)?;
+    let loaded = load(&cwd, global_agents().as_deref())?;
     let budget = budget_tokens();
     if loaded.tokens > budget {
         Some(format!(
@@ -42,14 +43,14 @@ pub fn budget_warning() -> Option<String> {
 
 pub fn summary() -> (String, usize) {
     match std::env::current_dir() {
-        Ok(cwd) => summary_in(&cwd),
+        Ok(cwd) => summary_in(&cwd, global_agents().as_deref()),
         Err(_) => ("no cwd".into(), 0),
     }
 }
 
-fn summary_in(cwd: &Path) -> (String, usize) {
-    let files = load_files(cwd);
-    let skills = load_skills(cwd);
+fn summary_in(cwd: &Path, global: Option<&Path>) -> (String, usize) {
+    let files = load_files(cwd, global);
+    let skills = load_skills(cwd, global);
     if files.is_empty() && skills.is_empty() {
         return ("no preamble".into(), 0);
     }
@@ -75,9 +76,9 @@ fn summary_in(cwd: &Path) -> (String, usize) {
     (out, tokens as usize)
 }
 
-fn load(cwd: &Path) -> Option<Loaded> {
-    let files = load_files(cwd);
-    let skills = load_skills(cwd);
+fn load(cwd: &Path, global: Option<&Path>) -> Option<Loaded> {
+    let files = load_files(cwd, global);
+    let skills = load_skills(cwd, global);
     if files.is_empty() && skills.is_empty() {
         return None;
     }
@@ -86,27 +87,51 @@ fn load(cwd: &Path) -> Option<Loaded> {
     Some(Loaded { text, tokens })
 }
 
-fn load_files(cwd: &Path) -> Vec<(String, String)> {
+fn global_agents() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|home| !home.is_empty())
+        .map(PathBuf::from)
+        .map(|home| home.join(".agents"))
+}
+
+fn load_files(cwd: &Path, global: Option<&Path>) -> Vec<(String, String)> {
     let mut files = Vec::new();
-    for name in CONTEXT_FILES {
-        let Ok(body) = fs::read_to_string(cwd.join(name)) else {
-            continue;
-        };
-        let body = body.trim();
-        if !body.is_empty() {
-            files.push(((*name).to_string(), body.to_string()));
-        }
+    let project_agents = cwd.join("AGENTS.md");
+    let agents = if project_agents.is_file() {
+        Some(("AGENTS.md".to_string(), project_agents))
+    } else {
+        global.map(|root| ("~/.agents/AGENTS.md".to_string(), root.join("AGENTS.md")))
+    };
+    if let Some((name, path)) = agents
+        && let Ok(body) = fs::read_to_string(path)
+        && !body.trim().is_empty()
+    {
+        files.push((name, body.trim().to_string()));
+    }
+    if let Ok(body) = fs::read_to_string(cwd.join(CONTEXT_FILE))
+        && !body.trim().is_empty()
+    {
+        files.push((CONTEXT_FILE.to_string(), body.trim().to_string()));
     }
     files
 }
 
-fn load_skills(cwd: &Path) -> Vec<Skill> {
-    let root = cwd.join(".agents").join("skills");
-    let entries = match fs::read_dir(&root) {
+fn load_skills(cwd: &Path, global: Option<&Path>) -> Vec<Skill> {
+    let mut skills = BTreeMap::new();
+    if let Some(root) = global {
+        load_skills_from(root, "~/.agents/skills", &mut skills);
+    }
+    load_skills_from(&cwd.join(".agents"), ".agents/skills", &mut skills);
+    let mut skills: Vec<_> = skills.into_values().collect();
+    skills.sort_by(|a, b| a.name.cmp(&b.name));
+    skills
+}
+
+fn load_skills_from(root: &Path, display_root: &str, skills: &mut BTreeMap<String, Skill>) {
+    let entries = match fs::read_dir(root.join("skills")) {
         Ok(entries) => entries,
-        Err(_) => return Vec::new(),
+        Err(_) => return,
     };
-    let mut skills = Vec::new();
     for entry in entries.flatten() {
         let path = entry.path();
         if !path.is_dir() {
@@ -122,15 +147,16 @@ fn load_skills(cwd: &Path) -> Vec<Skill> {
             .unwrap_or("skill")
             .to_string();
         let (fm_name, fm_desc) = parse_frontmatter(&body);
-        let rel = format!(".agents/skills/{dir_name}/SKILL.md");
-        skills.push(Skill {
-            name: fm_name.unwrap_or(dir_name),
-            description: fm_desc.unwrap_or_default(),
-            path: rel,
-        });
+        let rel = format!("{display_root}/{dir_name}/SKILL.md");
+        skills.insert(
+            dir_name.clone(),
+            Skill {
+                name: fm_name.unwrap_or(dir_name),
+                description: fm_desc.unwrap_or_default(),
+                path: rel,
+            },
+        );
     }
-    skills.sort_by(|a, b| a.name.cmp(&b.name));
-    skills
 }
 
 fn render(files: &[(String, String)], skills: &[Skill]) -> String {
@@ -250,7 +276,7 @@ mod tests {
     #[test]
     fn empty_cwd_is_none() {
         let dir = scratch();
-        assert!(load(&dir).is_none());
+        assert!(load(&dir, None).is_none());
     }
 
     #[test]
@@ -258,11 +284,60 @@ mod tests {
         let dir = scratch();
         fs::write(dir.join("AGENTS.md"), "be brief").unwrap();
         fs::write(dir.join("CONTEXT.md"), "repo facts").unwrap();
-        let text = load(&dir).unwrap().text;
+        let text = load(&dir, None).unwrap().text;
         assert!(text.contains("# AGENTS.md"));
         assert!(text.contains("be brief"));
         assert!(text.contains("# CONTEXT.md"));
         assert!(text.contains("repo facts"));
+    }
+
+    #[test]
+    fn project_agents_overrides_global_agents() {
+        let cwd = scratch();
+        let global = scratch();
+        fs::write(global.join("AGENTS.md"), "global rules").unwrap();
+
+        let text = load(&cwd, Some(&global)).unwrap().text;
+        assert!(text.contains("global rules"));
+
+        fs::write(cwd.join("AGENTS.md"), "project rules").unwrap();
+        let text = load(&cwd, Some(&global)).unwrap().text;
+        assert!(text.contains("project rules"));
+        assert!(!text.contains("global rules"));
+    }
+
+    #[test]
+    fn project_skills_override_global_by_directory_name() {
+        let cwd = scratch();
+        let global = scratch();
+        let global_review = global.join("skills/review");
+        let global_ship = global.join("skills/ship");
+        let project_review = cwd.join(".agents/skills/review");
+        fs::create_dir_all(&global_review).unwrap();
+        fs::create_dir_all(&global_ship).unwrap();
+        fs::create_dir_all(&project_review).unwrap();
+        fs::write(
+            global_review.join("SKILL.md"),
+            "---\nname: global-review\ndescription: Global review.\n---\n",
+        )
+        .unwrap();
+        fs::write(
+            global_ship.join("SKILL.md"),
+            "---\nname: ship\ndescription: Ship globally.\n---\n",
+        )
+        .unwrap();
+        fs::write(
+            project_review.join("SKILL.md"),
+            "---\nname: project-review\ndescription: Project review.\n---\n",
+        )
+        .unwrap();
+
+        let text = load(&cwd, Some(&global)).unwrap().text;
+        assert!(text.contains("project-review: Project review."));
+        assert!(text.contains(".agents/skills/review/SKILL.md"));
+        assert!(!text.contains("global-review"));
+        assert!(text.contains("ship: Ship globally."));
+        assert!(text.contains("~/.agents/skills/ship/SKILL.md"));
     }
 
     #[test]
@@ -275,7 +350,7 @@ mod tests {
             "---\nname: review\ndescription: Review a diff.\n---\n\nDo not paste this body.\n",
         )
         .unwrap();
-        let text = load(&dir).unwrap().text;
+        let text = load(&dir, None).unwrap().text;
         assert!(text.contains("# Skills"));
         assert!(text.contains("review: Review a diff."));
         assert!(text.contains(".agents/skills/review/SKILL.md"));
@@ -293,7 +368,7 @@ mod tests {
         )
         .unwrap();
 
-        let (summary, _) = summary_in(&dir);
+        let (summary, _) = summary_in(&dir, None);
         assert!(
             summary
                 .contains("    review  (`.agents/skills/review/SKILL.md`)\n      Review a diff.")
@@ -315,7 +390,7 @@ mod tests {
         let skill = dir.join(".agents").join("skills").join("notes");
         fs::create_dir_all(&skill).unwrap();
         fs::write(skill.join("SKILL.md"), "just a body\n").unwrap();
-        let text = load(&dir).unwrap().text;
+        let text = load(&dir, None).unwrap().text;
         assert!(text.contains("- notes (`.agents/skills/notes/SKILL.md`)"));
         assert!(!text.contains("just a body"));
     }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -457,6 +457,12 @@ fn stop_child(child: &mut Child) {
 }
 
 fn resolve(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/")
+        && let Some(home) = std::env::var_os("HOME")
+        && !home.is_empty()
+    {
+        return PathBuf::from(home).join(rest);
+    }
     let p = Path::new(path);
     if p.is_absolute() {
         p.to_path_buf()


### PR DESCRIPTION
## Summary

- fall back to `~/.agents/AGENTS.md` when the project has no `AGENTS.md`
- merge global and project skill summaries, with project skills overriding by directory name
- resolve `~/` in file tool paths so global skill files can be read
- document the prompt precedence and cover it with tests

## Checks

- `cargo fmt --check`
- `cargo clippy --quiet`
- `cargo test --quiet`
- `git diff --check`

🤖 Developed with [Lunar](https://github.com/gszr/lunar) 🌘
