### PR TITLE
feat: let each model list its thinking levels

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,7 +24,7 @@ You open `lunar` and talk. The binary does not dictate workflow (no MCP, sub-age
 | Trust | Not implemented. Project `.lunar/init.lua` runs automatically this slice |
 | Language | Lua 5.5.1, vendored via `mlua` (`lua55` + `vendored`). Embed this slice |
 | Lua guest API | `init.lua` returns one table containing optional `models`, `providers`, and `defaults` tables. The registrar form does not exist. **No `lunar.on`** (hook bus is not v0) |
-| Model catalog | Top-level `models`: alias → `{ id, window?, api?, thinking? }`. `id` is the wire string; alias is a Lua name. Provider `models` is an ordered list: string = ref to a global alias, table = local `{ id, window?, api?, thinking? }`. Missing alias = notice, skip that entry. Missing `id`, unknown `api`, or unknown `thinking` = notice, skip that entry. `thinking` is `off` · `low` · `medium` · `high`; a model value overrides its provider default. Omitted values resolve to `off`. Omitted `api` is Completions |
+| Model catalog | Top-level `models`: alias → `{ id, window?, api?, thinking? }`. `id` is the wire string; alias is a Lua name. Provider `models` is an ordered list: string = ref to a global alias, table = local `{ id, window?, api?, thinking? }`. Missing alias = notice, skip that entry. Missing `id`, unknown `api`, or invalid `thinking` = notice, skip that entry. Model `thinking` is an ordered table of model-specific wire values plus `default`, for example `{ "low", "high", "max", default = "high" }`; `default` must be listed. Omitted `thinking` resolves to `{ "off", default = "off" }`. Provider-level and scalar `thinking` do not exist. Omitted `api` is Completions |
 | Live model | Top-level `defaults = { provider, model }`. `provider` is a providers key; `model` matches that list as alias then wire `id`. Unknown provider or model is an error: notice, glass opens, cannot send. Omitted defaults = no live Config; the catalog remains available in `/model`. Partial defaults (only one field) = present and invalid. The selected provider must have `base_url_cmd` or `base_url` unless `key_in = "auth"` and `auth_provider` is `xai` or `openai` (then `https://api.x.ai/v1` or `https://chatgpt.com/backend-api`). `key_in = "none"` requires an explicit `base_url`; HTTP and HTTPS are accepted. Plus `key_cmd` or `key_name` (`key_in = "env"`), or `auth_provider` (`key_in = "auth"`); missing the applicable source = notice, cannot send. `base_url_cmd` takes precedence over `base_url`, which takes precedence over an auth default. Live `api` `"messages"` is resolve-time refuse: notice, cannot send, entry stays in `/model`. Completions and Responses send. Live Config carries optional `auth_provider` from Lua `key_in = "auth"`. `"openai"` means Codex Responses + JWT account header; Completions on that auth is refuse. Do not sniff `base_url`. Model `window` if set, else the Grok-id guess. Footer provider is the providers key |
 | Prompt conventions | CWD `AGENTS.md` + `CONTEXT.md` in full. Skill *summaries* from `.agents/skills/*/SKILL.md`. Optional bundled skills live in `skills/` and are installed manually per project; none are enabled by default. `~/.agents/skills` later |
 | System prompt | None. Context is a leading user message, snapshotted at each user submit, held for the tool loop, not persisted |
@@ -32,7 +32,7 @@ You open `lunar` and talk. The binary does not dictate workflow (no MCP, sub-age
 | Model protocol | Completions, Responses, and Messages. Selected by model `api`: `"completions"` · `"responses"` · `"messages"`. Case-sensitive, no aliases. Omitted `api` is Completions. Completions and Responses send. Responses stays `store: false`, requests an automatic reasoning summary for the thinking preview, and replays the full converted history each round. When a mission exists, Responses also sends `prompt_cache_key` (mission id, 64 chars max) and Pi affinity headers `session_id` / `x-client-request-id`. No `previous_response_id`. ChatGPT Plus (`auth_provider = "openai"`) is Responses-only: POST `{base_url}/codex/responses` (not `{base_url}/responses`), plus `chatgpt-account-id` decoded from the access JWT at send and refresh (`https://api.openai.com/auth` → `chatgpt_account_id`; missing or empty = notice, cannot send) and `originator: lunar`. No extra `auth.json` field. Completions on that auth is resolve-time refuse. No websocket and no zstd this slice. Messages is not implemented |
 | First brand | xAI. No provider is compiled into configuration |
 | Auth | Env named by Lua, shell command, Lunar-managed auth, or none. With `key_in = "env"`, `key_cmd` runs through `sh -c` and supplies the secret, otherwise `key_name` names an env secret. `key_in = "auth"` names a canonical built-in integration with `auth_provider` (`xai` or `openai`) and resolves API-key or OAuth credentials from `~/.lunar/recorder/auth.json`. `key_in = "none"` sends no Authorization header and requires an explicit `base_url`; `key_name`, `key_cmd`, and `auth_provider` are ignored. `/login` is a provider picker (`xAI`, `OpenAI`). Enter on xAI opens the existing method picker. Enter on OpenAI starts device-code immediately. `/login xai` opens the xAI method picker. `/login openai` is ChatGPT Plus/Pro subscription OAuth only (no stored platform API key this slice): device-code, same glass as xAI (open URL, show user code, poll, Esc cancels). No browser PKCE and no localhost callback this slice. `/logout xai` / `/logout openai` remove that credential; `/logout` with no argument notices usage. The xAI device flow uses the public client ID distributed by Pi. The OpenAI device flow uses the public Codex client ID distributed by Pi |
-| Thinking | `off` · `low` · `medium` · `high`. `/thinking` opens a one-line `<- off low medium high ->` picker; left/right selects and Enter applies. `/thinking <level>` applies directly. It changes the running Config for the current mission and is appended to that mission’s JSONL; reopening the mission restores its last level. Before the first prompt it is held in memory and written when the mission is created. `/new` returns to the configured default. Lua model value overrides provider default; omitted resolves to `off`. Completions sends `reasoning_effort`, Responses sends `reasoning.effort`; `off` omits effort. Footer shows the live level |
+| Thinking | Each model defines its ordered allowed wire values and default with `thinking = { "low", "high", "max", default = "high" }`. `/thinking` opens a one-line picker containing only the live model’s values; left/right selects and Enter applies. `/thinking <level>` applies directly only when that level is allowed by the live model. It changes the running Config for the current mission and is appended to that mission’s JSONL; reopening the mission restores its last level when the selected model still allows it. Before the first prompt it is held in memory and written when the mission is created. `/new` and model selection return to that model’s configured default. Omitted model `thinking` resolves to only `off`. Completions sends `reasoning_effort`, Responses sends `reasoning.effort`; the literal `off` omits effort. Footer shows the live level |
 | TUI | `ratatui` + `crossterm` |
 | Transcript | The current mission. Scrollable: every message in that mission is reachable as painted (tool cards stay 8 lines, thinking stays a 3-line preview). Not a tail-only view. `/resume` switches missions; there is no Session history object |
 | Tools | `read` / `write` / `edit` (`old_string`/`new_string`) / `bash`. Gate = allow. Bash timeout 60s, Esc kills the process group. Bash stdin is null; on Unix the child is a new session so a nested TUI cannot take the glass. Tool results cap 50KB or 2000 lines per result. `read` keeps the head and gives the next offset. `bash` keeps the tail; truncated bash output is saved under `~/.lunar/recorder/tool-output/` and the path is included in the result. Files older than seven days are deleted at startup. `finish_reason=length` does not execute tool calls. Calls in one assistant turn run in parallel. Tool loops pause after 50 rounds; submitting `continue` starts a fresh turn |
@@ -79,7 +79,12 @@ Host runs `~/.lunar/control/init.lua` (or `$LUNAR_HOME/control/init.lua`) and th
 ```lua
 return {
   models = {
-    grok46 = { id = "grok-4.6", window = 500000, api = "completions" },
+    grok46 = {
+      id = "grok-4.6",
+      window = 500000,
+      api = "completions",
+      thinking = { "low", "high", "max", default = "high" },
+    },
   },
 
   providers = {
@@ -90,10 +95,13 @@ return {
       -- key_cmd = "pass my_key" -- shell command; takes precedence over key_name
       -- key_in = "env", -- default if omitted
       -- key_in = "auth", auth_provider = "xai", -- ~/.lunar/recorder/auth.json via /login
-      thinking = "low", -- optional provider default
       models = {
         "grok46", -- ref: alias → global catalog
-        { id = "grok-4.5", api = "completions", thinking = "high" },
+        {
+          id = "grok-4.5",
+          api = "completions",
+          thinking = { "off", "low", "high", default = "low" },
+        },
       },
     },
   },
@@ -108,7 +116,7 @@ return {
 - **Provider name** is the table key, not a `name` field.
 - **Alias** is a Lua name (`grok46`). **`id`** is the wire string (`grok-4.6`). Every model def requires `id`; skip that entry if missing. `api` is `"completions"` · `"responses"` · `"messages"`; unknown value = notice, skip that entry (same as missing `id`). Omitted `api` is Completions, not an error.
 - Provider `models` is an **ordered list**. String = ref to a global alias (missing alias = notice, skip). Table = local `{ id, window?, api?, thinking? }`.
-- This slice honors **`id`**, optional **`window`**, optional **`api`**, and optional **`thinking`**. `api` is only on a model def. `thinking` may be `off`, `low`, `medium`, or `high` on a model def or provider; the model overrides the provider, and omission resolves to `off`. A string ref inherits the alias’s values. Omitted `api` is Completions. xAI models set `api` explicitly.
+- This slice honors **`id`**, optional **`window`**, optional **`api`**, and optional model **`thinking`**. `api` and `thinking` are only on a model def. `thinking` is an ordered list of that model’s non-empty wire values with a required `default` that must appear in the list. Duplicate values keep their first position. Omitted `thinking` resolves to `{ "off", default = "off" }`. Provider-level and scalar `thinking` are invalid. A string ref inherits the alias’s values. Omitted `api` is Completions. xAI models set `api` explicitly.
 - **`key_name`** is the env var to read when `key_in` is `"env"`. Token never sits in Lua.
 - **`key_cmd`** is an alternative when `key_in` is `"env"`. It runs through `sh -c` at config resolution, before Lunar enters TUI mode, so interactive credential helpers such as GPG pinentry can use the terminal; trailing whitespace is trimmed. Non-zero exit, non-UTF-8 output, or an empty key = notice, cannot send. When both are set, `key_cmd` wins.
 - **`key_in`** defaults to `"env"`. `"env"` reads `key_cmd` or `key_name`; `"auth"` reads `~/.lunar/recorder/auth.json` for `auth_provider` (`xai` or `openai`); `"none"` sends no Authorization header, ignores credential fields, and requires an explicit `base_url`. Any other value = notice, cannot send.
@@ -166,7 +174,7 @@ Transcript scroll: PageUp / PageDown, mouse wheel, Ctrl+Home / Ctrl+End to top /
 - CWD `AGENTS.md` / `CONTEXT.md` + `.agents/skills` summaries as a leading user message, snapshotted per user turn
 - Commands that exist: `/quit` `/q` `/help` `/new` `/resume` `/model` `/thinking` `/login` `/logout` `/name` `/mission` `/context`. `/context` opens a component summary of the live preamble and current history, with count and estimated-token breakdowns for user messages, assistant messages, tool calls, and tool results, plus a preamble + history total; `/context raw` shows their full contents, including tool calls and results. Both use a pager: PageUp/PageDown, j/k, wheel, and Ctrl+Home/End scroll, while Esc or q closes it
 - Lua 5.5 embed; user `~/.lunar/control/init.lua` returns `{ models, providers, defaults }`
-- Thinking levels: `/thinking off|low|medium|high`; Lua model value overrides provider default; Completions and Responses wire mappings; live level in footer
+- Thinking levels: each model supplies its ordered values and default; `/thinking` only accepts and displays those values; Completions and Responses wire mappings; live level in footer
 
 **Not shipped (still v0 intent)**
 

--- a/examples/xai.lua
+++ b/examples/xai.lua
@@ -6,7 +6,12 @@
 
 return {
   models = {
-    grok46 = { id = "grok-4.6", window = 500000, api = "completions" },
+    grok46 = {
+      id = "grok-4.6",
+      window = 500000,
+      api = "completions",
+      thinking = { "low", "high", "max", default = "high" },
+    },
   },
 
   providers = {
@@ -16,10 +21,13 @@ return {
       key_name = "XAI_API_KEY",
       -- key_cmd = "pass lunar/xai"
       -- key_in = "auth", auth_provider = "xai",
-      thinking = "low",
       models = {
         "grok46",
-        { id = "grok-4.5", api = "completions", thinking = "high" },
+        {
+          id = "grok-4.5",
+          api = "completions",
+          thinking = { "off", "low", "high", default = "low" },
+        },
       },
     },
   },

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::{self, TryRecvError};
 
 use crate::app::{App, AuthEvent, AuthPrompt, Mode};
-use crate::protocol::{Thinking, Usage};
+use crate::protocol::Usage;
 use crate::transcript::{invalidate_paint, jump_to_tail};
 use crate::turn::persist_value;
 use crate::view::draw;
@@ -147,45 +147,44 @@ fn logout_provider(app: &mut App, provider: &str, brand: &str) {
 }
 
 pub(crate) fn open_thinking(app: &mut App) {
-    let Some(level) = app.config.as_ref().map(|config| config.thinking) else {
+    let Some(config) = app.config.as_ref() else {
         app.notice = Some("no model configured".into());
         return;
     };
-    app.mode = Mode::Thinking {
-        cursor: match level {
-            Thinking::Off => 0,
-            Thinking::Low => 1,
-            Thinking::Medium => 2,
-            Thinking::High => 3,
-        },
-    };
+    let cursor = config
+        .thinking_levels
+        .iter()
+        .position(|level| level == &config.thinking)
+        .unwrap_or(0);
+    app.mode = Mode::Thinking { cursor };
 }
 
-pub(crate) fn set_thinking(app: &mut App, level: Thinking) -> bool {
+pub(crate) fn set_thinking(app: &mut App, level: &str) -> bool {
     let Some(config) = &mut app.config else {
         return false;
     };
-    app.thinking_override = Some(level);
-    config.thinking = level;
+    if !config.allows_thinking(level) {
+        return false;
+    }
+    app.thinking_override = Some(level.to_string());
+    config.thinking = level.to_string();
     if app.mission.is_some() {
         persist_value(app, &mission::thinking_line(level));
     }
     true
 }
 
-fn with_thinking_override(
-    mut config: Option<crate::protocol::Config>,
-    level: Option<Thinking>,
-) -> Option<crate::protocol::Config> {
-    if let (Some(config), Some(level)) = (&mut config, level) {
-        config.thinking = level;
-    }
-    config
-}
-
 pub(crate) fn reload_config(app: &mut App) {
     let loaded = lua::load();
-    app.config = with_thinking_override(loaded.config.clone(), app.thinking_override);
+    let mut config = loaded.config.clone();
+    if let (Some(config), Some(level)) = (&mut config, app.thinking_override.as_deref()) {
+        if config.allows_thinking(level) {
+            config.thinking = level.to_string();
+        } else {
+            app.thinking_override = None;
+        }
+    }
+    app.config = config;
     app.startup_config = loaded.config;
     app.models = loaded.models;
     if let Some(notice) = loaded.notice {
@@ -303,17 +302,17 @@ pub(crate) fn open_model(app: &mut App) {
 }
 
 pub(crate) fn select_model(app: &mut App, item: lua::ModelChoice, persist: bool) {
-    let Some(mut config) = item.config else {
+    let Some(config) = item.config else {
         app.notice = Some(item.error.unwrap_or_else(|| "model is unavailable".into()));
         return;
     };
-    if let Some(level) = app.thinking_override {
-        config.thinking = level;
-    }
+    app.thinking_override = None;
+    let default_thinking = config.thinking.clone();
     app.config = Some(config);
     app.notice = Some(format!("model: {} / {}", item.provider, item.id));
     if persist {
         persist_value(app, &mission::model_line(&item.provider, &item.id));
+        persist_value(app, &mission::thinking_line(&default_thinking));
     }
 }
 
@@ -364,8 +363,8 @@ pub(crate) fn resume_prefix(app: &mut App, prefix: &str) {
 pub(crate) fn load_mission(app: &mut App, path: &std::path::Path) {
     match mission::load(path) {
         Ok(loaded) => {
-            app.thinking_override = loaded.thinking;
-            app.config = with_thinking_override(app.startup_config.clone(), loaded.thinking);
+            app.thinking_override = None;
+            app.config = app.startup_config.clone();
             app.messages = loaded.messages;
             app.mission = Some(loaded.mission);
             invalidate_paint(app);
@@ -378,6 +377,21 @@ pub(crate) fn load_mission(app: &mut App, path: &std::path::Path) {
                 app.notice = Some(format!(
                     "saved model {provider} / {id} is no longer configured; using startup default"
                 ));
+            }
+            if let Some(level) = loaded.thinking {
+                match app.config.as_mut() {
+                    Some(config) if config.allows_thinking(&level) => {
+                        app.thinking_override = Some(level.clone());
+                        config.thinking = level;
+                    }
+                    Some(config) if app.notice.is_none() => {
+                        app.notice = Some(format!(
+                            "saved thinking level is not supported by {}: {level}",
+                            config.model
+                        ));
+                    }
+                    _ => {}
+                }
             }
             jump_to_tail(app);
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ pub(crate) struct App {
     pub(crate) messages: Vec<Message>,
     pub(crate) config: Option<Config>,
     pub(crate) startup_config: Option<Config>,
-    pub(crate) thinking_override: Option<crate::protocol::Thinking>,
+    pub(crate) thinking_override: Option<String>,
     pub(crate) models: Vec<lua::ModelChoice>,
     pub(crate) stream_rx: Option<Receiver<StreamEvent>>,
     pub(crate) cancel: Option<Arc<AtomicBool>>,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -45,7 +45,7 @@ pub const COMMANDS: &[Command] = &[
     },
     Command {
         name: "thinking",
-        description: "set reasoning effort: off, low, medium, high",
+        description: "set the model's reasoning effort",
     },
     Command {
         name: "resume",

--- a/src/event.rs
+++ b/src/event.rs
@@ -168,6 +168,11 @@ fn on_api_key(app: &mut App, key: KeyEvent) {
 }
 
 fn on_thinking_key(app: &mut App, key: KeyEvent, cursor: usize) {
+    let len = app
+        .config
+        .as_ref()
+        .map(|config| config.thinking_levels.len())
+        .unwrap_or(0);
     match key.code {
         KeyCode::Esc => app.mode = Mode::Chat,
         KeyCode::Left | KeyCode::Up | KeyCode::Char('h' | 'k') => {
@@ -177,19 +182,20 @@ fn on_thinking_key(app: &mut App, key: KeyEvent, cursor: usize) {
         }
         KeyCode::Right | KeyCode::Down | KeyCode::Char('l' | 'j') => {
             app.mode = Mode::Thinking {
-                cursor: (cursor + 1).min(3),
+                cursor: (cursor + 1).min(len.saturating_sub(1)),
             };
         }
         KeyCode::Enter => {
-            let level = [
-                crate::protocol::Thinking::Off,
-                crate::protocol::Thinking::Low,
-                crate::protocol::Thinking::Medium,
-                crate::protocol::Thinking::High,
-            ][cursor];
+            let level = app
+                .config
+                .as_ref()
+                .and_then(|config| config.thinking_levels.get(cursor))
+                .cloned();
             app.mode = Mode::Chat;
-            set_thinking(app, level);
-            app.notice = Some(format!("thinking: {}", level.as_str()));
+            if let Some(level) = level {
+                set_thinking(app, &level);
+                app.notice = Some(format!("thinking: {level}"));
+            }
         }
         _ => {}
     }
@@ -387,15 +393,16 @@ pub(crate) fn submit(app: &mut App) {
         "/model" => open_model(app),
         "/thinking" => open_thinking(app),
         cmd if let Some(raw) = cmd.strip_prefix("/thinking ") => {
-            match crate::protocol::Thinking::parse(raw.trim()) {
-                Some(level) => {
-                    if set_thinking(app, level) {
-                        app.notice = Some(format!("thinking: {}", level.as_str()));
-                    } else {
-                        app.notice = Some("no model configured".into());
-                    }
-                }
-                None => app.notice = Some("usage: /thinking off|low|medium|high".into()),
+            let level = raw.trim();
+            if set_thinking(app, level) {
+                app.notice = Some(format!("thinking: {level}"));
+            } else if let Some(config) = app.config.as_ref() {
+                app.notice = Some(format!(
+                    "usage: /thinking {}",
+                    config.thinking_levels.join("|")
+                ));
+            } else {
+                app.notice = Some("no model configured".into());
             }
         }
         "/mission" => show_mission(app),

--- a/src/lua/guest.rs
+++ b/src/lua/guest.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use mlua::{Table, Value};
 
-use crate::protocol::{Api, Thinking};
+use crate::protocol::Api;
 
 #[derive(Default)]
 pub(super) struct Guest {
@@ -21,11 +21,17 @@ pub(super) struct RawDefaults {
 }
 
 #[derive(Clone)]
+pub(super) struct ThinkingDef {
+    pub(super) levels: Vec<String>,
+    pub(super) default: String,
+}
+
+#[derive(Clone)]
 pub(super) struct ModelDef {
     pub(super) id: String,
     pub(super) window: Option<u32>,
     pub(super) api: Api,
-    pub(super) thinking: Option<Thinking>,
+    pub(super) thinking: ThinkingDef,
 }
 
 pub(super) struct ProviderDef {
@@ -35,7 +41,6 @@ pub(super) struct ProviderDef {
     pub(super) key_cmd: Option<String>,
     pub(super) key_in: String,
     pub(super) auth_provider: Option<String>,
-    pub(super) thinking: Option<Thinking>,
     pub(super) models: Vec<Listed>,
 }
 
@@ -132,7 +137,9 @@ fn parse_providers(table: &Table) -> (BTreeMap<String, ProviderDef>, Vec<String>
         };
         notices.extend(extra);
         let key_in = field_string(&t, "key_in").unwrap_or_else(|| "env".into());
-        let thinking = parse_thinking(&t, "thinking", &format!("provider {name}"), &mut notices);
+        if !matches!(t.get::<Value>("thinking"), Ok(Value::Nil) | Err(_)) {
+            notices.push(format!("provider {name} thinking is not supported"));
+        }
         providers.insert(
             name,
             ProviderDef {
@@ -142,7 +149,6 @@ fn parse_providers(table: &Table) -> (BTreeMap<String, ProviderDef>, Vec<String>
                 key_cmd: field_string(&t, "key_cmd"),
                 key_in,
                 auth_provider: field_string(&t, "auth_provider"),
-                thinking,
                 models,
             },
         );
@@ -171,7 +177,10 @@ fn parse_listed(table: &Table) -> (Vec<Listed>, Vec<String>) {
 enum DefError {
     NoId,
     UnknownApi(Option<String>),
-    UnknownThinking(Option<String>),
+    InvalidThinking,
+    EmptyThinking,
+    MissingThinkingDefault,
+    UnknownThinkingDefault(String),
 }
 
 fn model_def(table: &Table) -> Result<ModelDef, DefError> {
@@ -190,11 +199,12 @@ fn model_def(table: &Table) -> Result<ModelDef, DefError> {
         },
     };
     let thinking = match table.get::<Value>("thinking") {
-        Ok(Value::Nil) | Err(_) => None,
-        Ok(v) => match value_string(&v).and_then(|raw| Thinking::parse(&raw)) {
-            Some(level) => Some(level),
-            None => return Err(DefError::UnknownThinking(value_string(&v))),
+        Ok(Value::Nil) | Err(_) => ThinkingDef {
+            levels: vec!["off".into()],
+            default: "off".into(),
         },
+        Ok(Value::Table(value)) => parse_thinking(&value)?,
+        Ok(_) => return Err(DefError::InvalidThinking),
     };
     Ok(ModelDef {
         id,
@@ -204,25 +214,29 @@ fn model_def(table: &Table) -> Result<ModelDef, DefError> {
     })
 }
 
-fn parse_thinking(
-    table: &Table,
-    key: &str,
-    prefix: &str,
-    notices: &mut Vec<String>,
-) -> Option<Thinking> {
-    match table.get::<Value>(key) {
-        Ok(Value::Nil) | Err(_) => None,
-        Ok(value) => match value_string(&value).and_then(|raw| Thinking::parse(&raw)) {
-            Some(level) => Some(level),
-            None => {
-                notices.push(match value_string(&value) {
-                    Some(raw) => format!("{prefix} has unknown thinking: {raw}"),
-                    None => format!("{prefix} has unknown thinking"),
-                });
-                None
-            }
-        },
+fn parse_thinking(table: &Table) -> Result<ThinkingDef, DefError> {
+    let mut levels = Vec::new();
+    for value in table.sequence_values::<Value>() {
+        let Ok(value) = value else {
+            return Err(DefError::InvalidThinking);
+        };
+        let Some(level) = value_string(&value).filter(|level| !level.is_empty()) else {
+            return Err(DefError::InvalidThinking);
+        };
+        if !levels.contains(&level) {
+            levels.push(level);
+        }
     }
+    if levels.is_empty() {
+        return Err(DefError::EmptyThinking);
+    }
+    let default = field_string(table, "default")
+        .filter(|level| !level.is_empty())
+        .ok_or(DefError::MissingThinkingDefault)?;
+    if !levels.contains(&default) {
+        return Err(DefError::UnknownThinkingDefault(default));
+    }
+    Ok(ThinkingDef { levels, default })
 }
 
 fn def_error(prefix: &str, err: DefError) -> String {
@@ -230,10 +244,12 @@ fn def_error(prefix: &str, err: DefError) -> String {
         DefError::NoId => format!("{prefix} has no id"),
         DefError::UnknownApi(Some(raw)) => format!("{prefix} has unknown api: {raw}"),
         DefError::UnknownApi(None) => format!("{prefix} has unknown api"),
-        DefError::UnknownThinking(Some(raw)) => {
-            format!("{prefix} has unknown thinking: {raw}")
+        DefError::InvalidThinking => format!("{prefix} thinking is not a table of strings"),
+        DefError::EmptyThinking => format!("{prefix} thinking has no levels"),
+        DefError::MissingThinkingDefault => format!("{prefix} thinking has no default"),
+        DefError::UnknownThinkingDefault(raw) => {
+            format!("{prefix} thinking default is not listed: {raw}")
         }
-        DefError::UnknownThinking(None) => format!("{prefix} has unknown thinking"),
     }
 }
 

--- a/src/lua/resolve.rs
+++ b/src/lua/resolve.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 use std::process::Command;
 
-use crate::protocol::{self, Api, Config, Thinking};
+use crate::protocol::{self, Api, Config};
 
 use super::guest::{Guest, Listed, ModelDef, ProviderDef, RawDefaults};
 use super::{Loaded, ModelChoice};
@@ -144,7 +144,8 @@ fn provider_config(
         window: model.window.or_else(|| protocol::guess_window(&model.id)),
         api: model.api,
         auth_provider,
-        thinking: model.thinking.or(provider.thinking).unwrap_or_default(),
+        thinking: model.thinking.clone(),
+        thinking_levels: model.thinking_levels.clone(),
     })
 }
 
@@ -179,7 +180,8 @@ struct ResolvedModel {
     id: String,
     window: Option<u32>,
     api: Api,
-    thinking: Option<Thinking>,
+    thinking: String,
+    thinking_levels: Vec<String>,
 }
 
 fn resolve_listed(
@@ -196,7 +198,8 @@ fn resolve_listed(
                     id: def.id.clone(),
                     window: def.window,
                     api: def.api,
-                    thinking: def.thinking,
+                    thinking: def.thinking.default.clone(),
+                    thinking_levels: def.thinking.levels.clone(),
                 }),
                 None => notices.push(format!("unknown alias: {alias}")),
             },
@@ -205,7 +208,8 @@ fn resolve_listed(
                 id: def.id.clone(),
                 window: def.window,
                 api: def.api,
-                thinking: def.thinking,
+                thinking: def.thinking.default.clone(),
+                thinking_levels: def.thinking.levels.clone(),
             }),
         }
     }

--- a/src/lua/tests.rs
+++ b/src/lua/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::protocol::{Api, Thinking};
+use crate::protocol::Api;
 use std::fs;
 use std::sync::{Mutex, MutexGuard};
 
@@ -230,7 +230,7 @@ return {
 }
 
 #[test]
-fn model_thinking_overrides_provider_thinking() {
+fn model_thinking_lists_allowed_levels_and_default() {
     let _env = isolate(&[("XAI_API_KEY", "key")]);
     let dir = scratch();
     let path = write_init(
@@ -238,13 +238,15 @@ fn model_thinking_overrides_provider_thinking() {
         r#"
 return {
   models = {
-  grok = { id = "grok", thinking = "high" },
+  grok = {
+    id = "grok",
+    thinking = { "low", "high", "max", default = "high" },
+  },
 },
   providers = {
   xai = {
     base_url = "https://api.x.ai/v1",
     key_name = "XAI_API_KEY",
-    thinking = "low",
     models = { "grok", { id = "other" } },
   },
 },
@@ -253,9 +255,69 @@ return {
 "#,
     );
     let loaded = load_path(&path);
-    assert_eq!(loaded.config.unwrap().thinking, Thinking::High);
+    let config = loaded.config.unwrap();
+    assert_eq!(config.thinking, "high");
+    assert_eq!(config.thinking_levels, ["low", "high", "max"]);
     let other = loaded.models.iter().find(|m| m.id == "other").unwrap();
-    assert_eq!(other.config.as_ref().unwrap().thinking, Thinking::Low);
+    let other = other.config.as_ref().unwrap();
+    assert_eq!(other.thinking, "off");
+    assert_eq!(other.thinking_levels, ["off"]);
+}
+
+#[test]
+fn provider_thinking_is_rejected() {
+    let _env = isolate(&[("XAI_API_KEY", "key")]);
+    let src = r#"
+return {
+  providers = {
+    xai = {
+      base_url = "https://api.x.ai/v1",
+      key_name = "XAI_API_KEY",
+      thinking = "high",
+      models = { { id = "grok" } },
+    },
+  },
+  defaults = { provider = "xai", model = "grok" },
+}
+"#;
+    let loaded = load_path(&write_init(&scratch(), src));
+    assert_eq!(loaded.config.unwrap().thinking, "off");
+    assert_eq!(
+        loaded.notice.as_deref(),
+        Some("provider xai thinking is not supported")
+    );
+}
+
+#[test]
+fn invalid_model_thinking_is_skipped() {
+    let _env = isolate(&[("XAI_API_KEY", "key")]);
+    let src = r#"
+return {
+  models = {
+    scalar = { id = "scalar", thinking = "high" },
+    bad_default = {
+      id = "bad-default",
+      thinking = { "low", "high", default = "max" },
+    },
+  },
+  providers = {
+    xai = {
+      base_url = "https://api.x.ai/v1",
+      key_name = "XAI_API_KEY",
+      models = { "scalar", "bad_default", { id = "ok" } },
+    },
+  },
+  defaults = { provider = "xai", model = "ok" },
+}
+"#;
+    let loaded = load_path(&write_init(&scratch(), src));
+    assert_eq!(loaded.models.len(), 1);
+    assert_eq!(loaded.models[0].id, "ok");
+    let notice = loaded.notice.unwrap();
+    assert!(notice.contains("model scalar thinking is not a table of strings"));
+    assert!(notice.contains("model bad_default thinking default is not listed: max"));
+    assert!(notice.contains("unknown alias: scalar"));
+    assert!(notice.contains("unknown alias: bad_default"));
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ mod tests {
     use super::*;
     use crate::app::{Message, Mode};
     use crate::event::{on_key, on_paste};
-    use crate::protocol::{Api, Config, Thinking, ToolCall, Usage};
+    use crate::protocol::{Api, Config, ToolCall, Usage};
     use crate::transcript::painted_lines;
     use crate::transcript::{jump_to_tail, on_mouse};
     use crate::turn::{abort_turn, run_tools_parallel, skipped_truncated};
@@ -156,7 +156,8 @@ mod tests {
             window: None,
             api: Api::Completions,
             auth_provider: None,
-            thinking: Thinking::Off,
+            thinking: "off".into(),
+            thinking_levels: vec!["off".into(), "low".into(), "medium".into(), "high".into()],
         };
         app.config = Some(config.clone());
         app.startup_config = Some(config);
@@ -181,18 +182,35 @@ mod tests {
     }
 
     #[test]
-    fn thinking_without_value_opens_picker_and_selects_with_arrows() {
+    fn thinking_without_value_uses_the_model_levels() {
         let mut app = configured_app();
+        let config = app.config.as_mut().unwrap();
+        config.thinking = "high".into();
+        config.thinking_levels = vec!["low".into(), "high".into(), "max".into()];
         app.input = "/thinking".into();
         app.cursor = app.input.len();
         on_key(&mut app, key(KeyModifiers::NONE, KeyCode::Enter));
-        assert!(matches!(app.mode, Mode::Thinking { cursor: 0 }));
-        on_key(&mut app, key(KeyModifiers::NONE, KeyCode::Right));
+        assert!(matches!(app.mode, Mode::Thinking { cursor: 1 }));
         on_key(&mut app, key(KeyModifiers::NONE, KeyCode::Right));
         on_key(&mut app, key(KeyModifiers::NONE, KeyCode::Enter));
         assert!(matches!(app.mode, Mode::Chat));
-        assert_eq!(app.config.unwrap().thinking, Thinking::Medium);
-        assert_eq!(app.thinking_override, Some(Thinking::Medium));
+        assert_eq!(app.config.unwrap().thinking, "max");
+        assert_eq!(app.thinking_override, Some("max".into()));
+    }
+
+    #[test]
+    fn thinking_rejects_values_outside_the_model_levels() {
+        let mut app = configured_app();
+        app.config.as_mut().unwrap().thinking_levels =
+            vec!["low".into(), "high".into(), "max".into()];
+        app.input = "/thinking medium".into();
+        app.cursor = app.input.len();
+
+        on_key(&mut app, key(KeyModifiers::NONE, KeyCode::Enter));
+
+        assert_eq!(app.config.unwrap().thinking, "off");
+        assert_eq!(app.thinking_override, None);
+        assert_eq!(app.notice.as_deref(), Some("usage: /thinking low|high|max"));
     }
 
     #[test]
@@ -217,8 +235,75 @@ mod tests {
         )
         .unwrap();
         crate::actions::load_mission(&mut app, &path);
-        assert_eq!(app.thinking_override, Some(Thinking::High));
-        assert_eq!(app.config.unwrap().thinking, Thinking::High);
+        assert_eq!(app.thinking_override, Some("high".into()));
+        assert_eq!(app.config.unwrap().thinking, "high");
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn reopening_mission_ignores_a_thinking_level_the_model_no_longer_allows() {
+        let mut app = configured_app();
+        let dir = std::env::temp_dir().join(format!(
+            "lunar-thinking-resume-invalid-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("2026-08-19-1.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"header\",\"id\":\"2026-08-19-1\",\"name\":\"Thinking\"}\n",
+                "{\"type\":\"thinking\",\"level\":\"max\"}\n"
+            ),
+        )
+        .unwrap();
+
+        crate::actions::load_mission(&mut app, &path);
+
+        assert_eq!(app.thinking_override, None);
+        assert_eq!(app.config.as_ref().unwrap().thinking, "off");
+        assert_eq!(
+            app.notice.as_deref(),
+            Some("saved thinking level is not supported by grok: max")
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn reopening_mission_keeps_the_missing_model_notice() {
+        let mut app = configured_app();
+        let dir = std::env::temp_dir().join(format!(
+            "lunar-thinking-resume-missing-model-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("2026-08-19-1.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"header\",\"id\":\"2026-08-19-1\",\"name\":\"Thinking\"}\n",
+                "{\"type\":\"model\",\"provider\":\"openai\",\"id\":\"gpt-5\"}\n",
+                "{\"type\":\"thinking\",\"level\":\"max\"}\n"
+            ),
+        )
+        .unwrap();
+
+        crate::actions::load_mission(&mut app, &path);
+
+        assert_eq!(app.thinking_override, None);
+        assert_eq!(app.config.as_ref().unwrap().thinking, "off");
+        assert_eq!(
+            app.notice.as_deref(),
+            Some("saved model openai / gpt-5 is no longer configured; using startup default")
+        );
         std::fs::remove_dir_all(dir).unwrap();
     }
 
@@ -290,10 +375,10 @@ mod tests {
         app.input = "/thinking high".into();
         app.cursor = app.input.len();
         on_key(&mut app, key(KeyModifiers::NONE, KeyCode::Enter));
-        assert_eq!(app.thinking_override, Some(Thinking::High));
+        assert_eq!(app.thinking_override, Some("high".into()));
         crate::actions::new_mission(&mut app);
         assert_eq!(app.thinking_override, None);
-        assert_eq!(app.config.unwrap().thinking, Thinking::Off);
+        assert_eq!(app.config.unwrap().thinking, "off");
     }
 
     #[test]

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -8,7 +8,7 @@ use std::time::SystemTime;
 use serde_json::{Value, json};
 
 use crate::app::Message;
-use crate::protocol::{Thinking, ToolCall, Usage};
+use crate::protocol::{ToolCall, Usage};
 
 pub struct Mission {
     pub path: PathBuf,
@@ -114,7 +114,7 @@ pub struct Loaded {
     pub mission: Mission,
     pub messages: Vec<Message>,
     pub model: Option<(String, String)>,
-    pub thinking: Option<Thinking>,
+    pub thinking: Option<String>,
     pub usage: Usage,
     pub last_prompt: u32,
 }
@@ -279,12 +279,8 @@ pub fn load(path: &Path) -> io::Result<Loaded> {
                 }
             }
             Some("thinking") => {
-                if let Some(level) = value
-                    .get("level")
-                    .and_then(Value::as_str)
-                    .and_then(Thinking::parse)
-                {
-                    thinking = Some(level);
+                if let Some(level) = value.get("level").and_then(Value::as_str) {
+                    thinking = Some(level.to_string());
                 }
             }
             Some("usage") => {
@@ -352,8 +348,8 @@ pub fn model_line(provider: &str, id: &str) -> Value {
     json!({ "type": "model", "provider": provider, "id": id })
 }
 
-pub fn thinking_line(level: Thinking) -> Value {
-    json!({ "type": "thinking", "level": level.as_str() })
+pub fn thinking_line(level: &str) -> Value {
+    json!({ "type": "thinking", "level": level })
 }
 
 pub fn usage_line(usage: Usage) -> Value {
@@ -580,12 +576,12 @@ mod tests {
             format!(
                 "{}\n{}\n",
                 json!({"type":"header","id":"2026-08-19-1","name":"Thinking"}),
-                thinking_line(Thinking::High)
+                thinking_line("high")
             ),
         )
         .unwrap();
         let loaded = load(&path).unwrap();
-        assert_eq!(loaded.thinking, Some(Thinking::High));
+        assert_eq!(loaded.thinking, Some("high".into()));
         fs::remove_dir_all(dir).unwrap();
     }
 
@@ -604,7 +600,7 @@ mod tests {
         let lines = [
             json!({"type":"header","id":"2026-08-19-1","name":"Loaded"}),
             model_line("xai", "grok-old"),
-            thinking_line(Thinking::Low),
+            thinking_line("low"),
             user_line("hello"),
             assistant_line("hi", &[]),
             tool_line("call-1", "read", "contents"),
@@ -615,7 +611,7 @@ mod tests {
                 cache_write: 1,
             }),
             model_line("openai", "gpt-current"),
-            thinking_line(Thinking::High),
+            thinking_line("high"),
             usage_line(Usage {
                 input: 20,
                 output: 4,
@@ -637,7 +633,7 @@ mod tests {
         let loaded = load(&path).unwrap();
 
         assert_eq!(loaded.model, Some(("openai".into(), "gpt-current".into())));
-        assert_eq!(loaded.thinking, Some(Thinking::High));
+        assert_eq!(loaded.thinking, Some("high".into()));
         assert_eq!(loaded.usage.input, 30);
         assert_eq!(loaded.usage.output, 6);
         assert_eq!(loaded.usage.cache_read, 8);

--- a/src/protocol/completions.rs
+++ b/src/protocol/completions.rs
@@ -182,8 +182,8 @@ fn body(cfg: &Config, messages: &[ChatMessage]) -> String {
     } else {
         body["max_tokens"] = json!(MAX_TOKENS);
     }
-    if cfg.thinking != super::Thinking::Off {
-        body["reasoning_effort"] = json!(cfg.thinking.as_str());
+    if cfg.thinking != "off" {
+        body["reasoning_effort"] = json!(&cfg.thinking);
     }
     body.to_string()
 }
@@ -216,7 +216,8 @@ mod tests {
             window: Some(500_000),
             api: Api::Completions,
             auth_provider: None,
-            thinking: super::super::Thinking::Off,
+            thinking: "off".into(),
+            thinking_levels: vec!["off".into()],
         };
         let body: Value = serde_json::from_str(&body(&cfg, &[])).unwrap();
         assert_eq!(body["max_tokens"], MAX_TOKENS);
@@ -234,10 +235,11 @@ mod tests {
             window: None,
             api: Api::Completions,
             auth_provider: None,
-            thinking: super::super::Thinking::High,
+            thinking: "max".into(),
+            thinking_levels: vec!["low".into(), "high".into(), "max".into()],
         };
         let parsed: Value = serde_json::from_str(&body(&cfg, &[])).unwrap();
-        assert_eq!(parsed["reasoning_effort"], "high");
+        assert_eq!(parsed["reasoning_effort"], "max");
     }
 
     #[test]
@@ -250,7 +252,8 @@ mod tests {
             window: None,
             api: Api::Completions,
             auth_provider: None,
-            thinking: super::super::Thinking::Off,
+            thinking: "off".into(),
+            thinking_levels: vec!["off".into()],
         };
         let parsed: Value = serde_json::from_str(&body(&cfg, &[])).unwrap();
         assert_eq!(parsed["max_completion_tokens"], MAX_TOKENS);

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -34,36 +34,6 @@ impl Api {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum Thinking {
-    #[default]
-    Off,
-    Low,
-    Medium,
-    High,
-}
-
-impl Thinking {
-    pub fn parse(raw: &str) -> Option<Self> {
-        match raw {
-            "off" => Some(Self::Off),
-            "low" => Some(Self::Low),
-            "medium" => Some(Self::Medium),
-            "high" => Some(Self::High),
-            _ => None,
-        }
-    }
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Off => "off",
-            Self::Low => "low",
-            Self::Medium => "medium",
-            Self::High => "high",
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct Config {
     pub api_key: String,
@@ -73,7 +43,8 @@ pub struct Config {
     pub window: Option<u32>,
     pub api: Api,
     pub auth_provider: Option<String>,
-    pub thinking: Thinking,
+    pub thinking: String,
+    pub thinking_levels: Vec<String>,
 }
 
 impl Config {
@@ -83,6 +54,10 @@ impl Config {
 
     pub fn provider(&self) -> &str {
         &self.provider
+    }
+
+    pub fn allows_thinking(&self, level: &str) -> bool {
+        self.thinking_levels.iter().any(|allowed| allowed == level)
     }
 }
 

--- a/src/protocol/responses.rs
+++ b/src/protocol/responses.rs
@@ -173,16 +173,16 @@ fn body(cfg: &Config, messages: &[ChatMessage], cache_key: Option<&str>) -> Stri
         "store": false,
         "reasoning": {
             "summary": "auto",
-            "effort": if cfg.thinking == super::Thinking::Off {
+            "effort": if cfg.thinking == "off" {
                 Value::Null
             } else {
-                json!(cfg.thinking.as_str())
+                json!(&cfg.thinking)
             },
         },
         "tools": tools::responses_definitions(),
         "input": flatten_input(messages),
     });
-    if cfg.thinking == super::Thinking::Off {
+    if cfg.thinking == "off" {
         value["reasoning"].as_object_mut().unwrap().remove("effort");
     }
     if let Some(key) = cache_key {
@@ -342,7 +342,8 @@ mod tests {
             window: None,
             api: Api::Responses,
             auth_provider: None,
-            thinking: super::super::Thinking::Off,
+            thinking: "off".into(),
+            thinking_levels: vec!["off".into()],
         }
     }
 
@@ -365,9 +366,10 @@ mod tests {
     #[test]
     fn configured_thinking_sets_reasoning_effort() {
         let mut cfg = sample_cfg();
-        cfg.thinking = super::super::Thinking::Medium;
+        cfg.thinking = "max".into();
+        cfg.thinking_levels = vec!["low".into(), "high".into(), "max".into()];
         let parsed: Value = serde_json::from_str(&body(&cfg, &[], None)).unwrap();
-        assert_eq!(parsed["reasoning"]["effort"], "medium");
+        assert_eq!(parsed["reasoning"]["effort"], "max");
     }
 
     #[test]

--- a/src/turn.rs
+++ b/src/turn.rs
@@ -245,7 +245,7 @@ pub(crate) fn persist_value(app: &mut App, value: &serde_json::Value) {
     if let Some(m) = &app.mission {
         if created
             && value.get("type").and_then(serde_json::Value::as_str) != Some("thinking")
-            && let Some(level) = app.thinking_override
+            && let Some(level) = app.thinking_override.as_deref()
             && let Err(err) = mission::append(m, &mission::thinking_line(level))
         {
             app.notice = Some(format!("mission: {err}"));

--- a/src/view.rs
+++ b/src/view.rs
@@ -494,12 +494,17 @@ pub(crate) fn draw_thinking_editor(frame: &mut Frame, area: Rect, app: &App, cur
         .split(inner);
     draw_editor_input(frame, chunks[0], app);
     let mut spans = vec![Span::styled("<-  ", Style::default().fg(splash::ASH))];
-    for (i, level) in ["off", "low", "medium", "high"].iter().enumerate() {
+    let levels = app
+        .config
+        .as_ref()
+        .map(|config| config.thinking_levels.as_slice())
+        .unwrap_or(&[]);
+    for (i, level) in levels.iter().enumerate() {
         if i > 0 {
             spans.push(Span::raw("   "));
         }
         spans.push(Span::styled(
-            *level,
+            level.as_str(),
             Style::default().fg(if i == cursor {
                 splash::GOLD
             } else {
@@ -597,12 +602,7 @@ pub(crate) fn draw_footer(frame: &mut Frame, area: Rect, app: &App) {
     let cwd = Line::from(Span::styled(cwd_label(), Style::default().fg(splash::DUST)));
     let stats = stats_line(app);
     let model = match &app.config {
-        Some(cfg) => format!(
-            "({}) {} • {}",
-            cfg.provider(),
-            cfg.model,
-            cfg.thinking.as_str()
-        ),
+        Some(cfg) => format!("({}) {} • {}", cfg.provider(), cfg.model, cfg.thinking),
         None => "no model".into(),
     };
     let stats_row = spread(


### PR DESCRIPTION
Each model now owns its thinking vocabulary instead of a host enum of `off`/`low`/`medium`/`high`.

```lua
thinking = { "low", "high", "max", default = "high" }
```

- `/thinking` and `/thinking <level>` only accept the live model's listed values
- omitted `thinking` resolves to `{ "off", default = "off" }`
- scalar and provider-level thinking are invalid
- `/new` and model selection return to that model's default
- resume restores a saved level only if the selected model still allows it
- Completions and Responses send the wire string; literal `off` still omits effort

🤖 Developed with [Lunar](https://github.com/gszr/lunar) 🌘