### PR TITLE
fix: interrupt stale streams after resume

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -167,7 +167,7 @@ Transcript scroll: PageUp / PageDown, mouse wheel, Ctrl+Home / Ctrl+End to top /
 
 **Shipped**
 
-- Glass, Completions and Responses streams, reused HTTP agent, no global timeout. Completions `max_tokens` 32768 (reasoning + answer). POST retries 429/5xx/reset (3 times, 0.5s…8s, Esc cancels the wait). Completions `finish_reason` / Responses `response.completed` ends the turn; leftover Completions SSE is drained for usage (1s cap) and `[DONE]` in the background so the socket can return to the pool. Transcript scroll: PageUp / PageDown, wheel, Ctrl+Home / Ctrl+End; follow only at the tail. History paint is cached; only the streaming tail is re-wrapped
+- Glass, Completions and Responses streams, reused HTTP agent, no global timeout. Completions `max_tokens` 32768 (reasoning + answer). POST retries 429/5xx/reset (3 times, 0.5s…8s, Esc cancels the wait). Completions `finish_reason` / Responses `response.completed` ends the turn; leftover Completions SSE is drained for usage (1s cap) and `[DONE]` in the background so the socket can return to the pool. A computer resume detected during an active turn interrupts the stale turn, preserves partial output, and returns control to the user. Transcript scroll: PageUp / PageDown, wheel, Ctrl+Home / Ctrl+End; follow only at the tail. History paint is cached; only the streaming tail is re-wrapped
 - Four tools + continue-after-tools (50-round cap; submit `continue` to proceed). Tools in one round run in parallel. Results cap 50KB or 2000 lines; truncated bash output is saved under `~/.lunar/recorder/tool-output/`. Truncated completions do not run tool calls
 - Missions: `/new` `/resume` `/name` `/mission`, `-c`
 - Token stats + refuse submit when last prompt ≥ window

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use ratatui::DefaultTerminal;
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -22,8 +22,16 @@ use crate::transcript::{jump_to_tail, on_mouse, page_delta, scroll_by, scroll_ho
 use crate::turn::{abort_turn, drain_stream, send_prompt};
 use crate::view::draw;
 
+const RESUME_GAP: Duration = Duration::from_secs(30);
+
 pub(crate) fn run(terminal: &mut DefaultTerminal, app: &mut App) -> io::Result<()> {
+    let mut last_tick = SystemTime::now();
     while !app.quit {
+        let now = SystemTime::now();
+        if resumed_during_turn(app.cancel.is_some(), last_tick, now) {
+            interrupt_resumed_turn(app);
+        }
+        last_tick = now;
         drain_stream(app);
         drain_auth(app);
         terminal.draw(|frame| draw(frame, app))?;
@@ -42,6 +50,18 @@ pub(crate) fn run(terminal: &mut DefaultTerminal, app: &mut App) -> io::Result<(
         }
     }
     Ok(())
+}
+
+pub(crate) fn resumed_during_turn(active: bool, before: SystemTime, now: SystemTime) -> bool {
+    active
+        && now
+            .duration_since(before)
+            .is_ok_and(|elapsed| elapsed > RESUME_GAP)
+}
+
+pub(crate) fn interrupt_resumed_turn(app: &mut App) {
+    abort_turn(app);
+    app.notice = Some("computer resumed; interrupted model stream".into());
 }
 
 pub(crate) fn on_paste(app: &mut App, text: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ fn main() -> io::Result<()> {
 mod tests {
     use super::*;
     use crate::app::{Message, Mode};
-    use crate::event::{on_key, on_paste};
+    use crate::event::{interrupt_resumed_turn, on_key, on_paste, resumed_during_turn};
     use crate::protocol::{Api, Config, ToolCall, Usage};
     use crate::transcript::painted_lines;
     use crate::transcript::{jump_to_tail, on_mouse};
@@ -106,6 +106,7 @@ mod tests {
     use ratatui::crossterm::event::{MouseEvent, MouseEventKind};
     use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, mpsc};
+    use std::time::{Duration, SystemTime};
 
     fn test_app() -> App {
         App {
@@ -587,6 +588,41 @@ mod tests {
             arguments: "{}".into(),
         });
         assert_eq!(working_text(&app), " Running tools...");
+    }
+
+    #[test]
+    fn long_clock_gap_only_interrupts_an_active_turn() {
+        let before = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
+        let after = before + Duration::from_secs(31);
+        assert!(resumed_during_turn(true, before, after));
+        assert!(!resumed_during_turn(false, before, after));
+        assert!(!resumed_during_turn(
+            true,
+            before,
+            before + Duration::from_secs(30)
+        ));
+        assert!(!resumed_during_turn(true, after, before));
+    }
+
+    #[test]
+    fn resume_interrupt_preserves_partial_output() {
+        let mut app = test_app();
+        app.cancel = Some(Arc::new(AtomicBool::new(false)));
+        let (_tx, rx) = mpsc::channel();
+        app.stream_rx = Some(rx);
+        let mut assistant = Message::assistant();
+        assistant.text = "partial answer".into();
+        app.messages.push(assistant);
+
+        interrupt_resumed_turn(&mut app);
+
+        assert!(app.cancel.is_none());
+        assert!(app.stream_rx.is_none());
+        assert_eq!(app.messages.last().unwrap().text, "partial answer");
+        assert_eq!(
+            app.notice.as_deref(),
+            Some("computer resumed; interrupted model stream")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- detect a wall-clock gap while a model turn is active
- interrupt the stale stream after computer resume while preserving partial output
- return control to the user with a clear notice instead of remaining stuck on Thinking
- document the recovery behavior

Automatic replay is intentionally avoided so generations and tool calls cannot be duplicated.

## Checks

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`