### PR TITLE
fix: resolve provider credentials once

### DIFF
--- a/src/lua/resolve.rs
+++ b/src/lua/resolve.rs
@@ -87,12 +87,10 @@ fn provider_config(
     model: &ResolvedModel,
     providers: &mut BTreeMap<String, Result<ResolvedProvider, String>>,
 ) -> Result<Config, String> {
-    let provider = providers
-        .entry(provider_key.to_string())
-        .or_insert_with(|| resolve_provider(provider_key, provider))
-        .clone()?;
     if model.api == Api::Messages
-        || (provider.auth_provider.as_deref() == Some("openai") && model.api != Api::Responses)
+        || (provider.key_in == "auth"
+            && provider.auth_provider.as_deref() == Some("openai")
+            && model.api != Api::Responses)
     {
         let name = model.alias.as_deref().unwrap_or(model.id.as_str());
         return Err(format!(
@@ -100,6 +98,10 @@ fn provider_config(
             model.api.as_str()
         ));
     }
+    let provider = providers
+        .entry(provider_key.to_string())
+        .or_insert_with(|| resolve_provider(provider_key, provider))
+        .clone()?;
     Ok(Config {
         api_key: provider.api_key,
         base_url: provider.base_url,

--- a/src/lua/resolve.rs
+++ b/src/lua/resolve.rs
@@ -9,14 +9,15 @@ use super::guest::{Guest, Listed, ModelDef, ProviderDef, RawDefaults};
 use super::{Loaded, ModelChoice};
 
 pub(super) fn loaded(guest: &Guest) -> Loaded {
+    let mut providers = BTreeMap::new();
     let Some(defaults) = &guest.defaults else {
         return Loaded {
             config: None,
-            models: choices(guest),
+            models: choices(guest, &mut providers),
             notice: None,
         };
     };
-    match config_from_lua(guest, defaults) {
+    match config_from_lua(guest, defaults, &mut providers) {
         Ok((config, extra)) => {
             let notice = join_notices(
                 guest
@@ -27,7 +28,7 @@ pub(super) fn loaded(guest: &Guest) -> Loaded {
             );
             Loaded {
                 config: Some(config),
-                models: choices(guest),
+                models: choices(guest, &mut providers),
                 notice,
             }
         }
@@ -41,19 +42,22 @@ pub(super) fn loaded(guest: &Guest) -> Loaded {
             );
             Loaded {
                 config: None,
-                models: choices(guest),
+                models: choices(guest, &mut providers),
                 notice: combined,
             }
         }
     }
 }
 
-fn choices(guest: &Guest) -> Vec<ModelChoice> {
+fn choices(
+    guest: &Guest,
+    providers: &mut BTreeMap<String, Result<ResolvedProvider, String>>,
+) -> Vec<ModelChoice> {
     let mut out = Vec::new();
     for (provider_key, provider) in &guest.providers {
         let (models, _) = resolve_listed(&guest.models, &provider.models);
         for model in models {
-            let result = provider_config(provider_key, provider, &model);
+            let result = provider_config(provider_key, provider, &model, providers);
             let (config, error) = match result {
                 Ok(config) => (Some(config), None),
                 Err(error) => (None, Some(error)),
@@ -70,11 +74,49 @@ fn choices(guest: &Guest) -> Vec<ModelChoice> {
     out
 }
 
+#[derive(Clone)]
+struct ResolvedProvider {
+    api_key: String,
+    base_url: String,
+    auth_provider: Option<String>,
+}
+
 fn provider_config(
     provider_key: &str,
     provider: &ProviderDef,
     model: &ResolvedModel,
+    providers: &mut BTreeMap<String, Result<ResolvedProvider, String>>,
 ) -> Result<Config, String> {
+    let provider = providers
+        .entry(provider_key.to_string())
+        .or_insert_with(|| resolve_provider(provider_key, provider))
+        .clone()?;
+    if model.api == Api::Messages
+        || (provider.auth_provider.as_deref() == Some("openai") && model.api != Api::Responses)
+    {
+        let name = model.alias.as_deref().unwrap_or(model.id.as_str());
+        return Err(format!(
+            "{name} uses {}, not implemented",
+            model.api.as_str()
+        ));
+    }
+    Ok(Config {
+        api_key: provider.api_key,
+        base_url: provider.base_url,
+        model: model.id.clone(),
+        provider: provider_key.to_string(),
+        window: model.window.or_else(|| protocol::guess_window(&model.id)),
+        api: model.api,
+        auth_provider: provider.auth_provider,
+        thinking: model.thinking.clone(),
+        thinking_levels: model.thinking_levels.clone(),
+    })
+}
+
+fn resolve_provider(
+    provider_key: &str,
+    provider: &ProviderDef,
+) -> Result<ResolvedProvider, String> {
     let auth_provider = match provider.key_in.as_str() {
         "env" | "none" => None,
         "auth" => {
@@ -111,15 +153,6 @@ fn provider_config(
                 .to_string(),
         }
     };
-    if model.api == Api::Messages
-        || (auth_provider.as_deref() == Some("openai") && model.api != Api::Responses)
-    {
-        let name = model.alias.as_deref().unwrap_or(model.id.as_str());
-        return Err(format!(
-            "{name} uses {}, not implemented",
-            model.api.as_str()
-        ));
-    }
     let api_key = match provider.key_in.as_str() {
         "env" => match provider.key_cmd.as_deref().filter(|s| !s.is_empty()) {
             Some(command) => command_value(provider_key, "key_cmd", command)?,
@@ -136,20 +169,18 @@ fn provider_config(
         "none" => String::new(),
         _ => unreachable!(),
     };
-    Ok(Config {
+    Ok(ResolvedProvider {
         api_key,
         base_url,
-        model: model.id.clone(),
-        provider: provider_key.to_string(),
-        window: model.window.or_else(|| protocol::guess_window(&model.id)),
-        api: model.api,
         auth_provider,
-        thinking: model.thinking.clone(),
-        thinking_levels: model.thinking_levels.clone(),
     })
 }
 
-fn config_from_lua(guest: &Guest, defaults: &RawDefaults) -> Result<(Config, Vec<String>), String> {
+fn config_from_lua(
+    guest: &Guest,
+    defaults: &RawDefaults,
+    providers: &mut BTreeMap<String, Result<ResolvedProvider, String>>,
+) -> Result<(Config, Vec<String>), String> {
     let provider_key = defaults
         .provider
         .as_deref()
@@ -169,7 +200,7 @@ fn config_from_lua(guest: &Guest, defaults: &RawDefaults) -> Result<(Config, Vec
         Some(model) => model,
         None => return Err(join_parts(skips, format!("unknown model: {model_key}"))),
     };
-    match provider_config(provider_key, provider, chosen) {
+    match provider_config(provider_key, provider, chosen, providers) {
         Ok(config) => Ok((config, skips)),
         Err(err) => Err(join_parts(skips, err)),
     }

--- a/src/lua/tests.rs
+++ b/src/lua/tests.rs
@@ -616,6 +616,34 @@ return {
 }
 
 #[test]
+fn provider_commands_run_once_for_all_models() {
+    let _e = isolate(&[]);
+    let dir = scratch();
+    let count = dir.join("count");
+    let src = format!(
+        r#"
+return {{
+  providers = {{
+    xai = {{
+      base_url = "https://api.x.ai/v1",
+      key_cmd = "printf x >> '{}'; printf command-key",
+      models = {{ {{ id = "one" }}, {{ id = "two" }}, {{ id = "three" }} }},
+    }},
+  }},
+  defaults = {{ provider = "xai", model = "one" }},
+}}
+"#,
+        count.display()
+    );
+
+    let loaded = load_path(&write_init(&dir, &src));
+
+    assert!(loaded.config.is_some());
+    assert_eq!(loaded.models.len(), 3);
+    assert_eq!(fs::read_to_string(count).unwrap(), "x");
+}
+
+#[test]
 fn failing_key_cmd_cannot_send() {
     let _e = isolate(&[]);
     let src = r#"


### PR DESCRIPTION
## Summary

- resolve provider credentials and base URLs once during Lua config loading
- reuse provider resolution across the default model and catalog choices
- cache provider failures and cover command execution with a regression test

## Checks

- `cargo fmt --check`
- `cargo test lua::tests -- --test-threads=1`
- `cargo clippy --all-targets --all-features -- -D warnings`

🤖 Developed with [Lunar](https://github.com/gszr/lunar) 🌘