### PR TITLE
feat: add manual context compaction

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,7 +37,7 @@ You open `lunar` and talk. The binary does not dictate workflow (no MCP, sub-age
 | Transcript | The current mission. Scrollable: every message in that mission is reachable as painted (tool cards stay 8 lines, thinking stays a 3-line preview). Not a tail-only view. `/resume` switches missions; there is no Session history object |
 | Tools | `read` / `write` / `edit` (`old_string`/`new_string`) / `bash`. Gate = allow. Bash timeout 60s, Esc kills the process group. Bash stdin is null; on Unix the child is a new session so a nested TUI cannot take the glass. Tool results cap 50KB or 2000 lines per result. `read` keeps the head and gives the next offset. `bash` keeps the tail; truncated bash output is saved under `~/.lunar/recorder/tool-output/` and the path is included in the result. Files older than seven days are deleted at startup. `finish_reason=length` does not execute tool calls. Calls in one assistant turn run in parallel. Tool loops pause after 100 rounds; submitting `continue` starts a fresh turn |
 | Missions | Linear append-only jsonl. Not a tree. Not Pi-compatible. Each model usage result is appended; reopening sums the mission totals for the footer and restores the latest prompt size. Mission lists are ordered by file modification time, newest first; opening or listing a mission does not modify it, while prompts, model/thinking changes, and renames bump it |
-| Full context | Warn and refuse submit. No auto-compact. `/compact` only after this hurts |
+| Full context | Warn and refuse submit. No auto-compact. Manual `/compact [instructions]` uses the live model without tools to summarize older history while retaining about 20k recent estimated tokens. It cuts only at user/assistant boundaries (never at a tool result), truncates tool results to 2k characters in the summarization request, and appends a compaction checkpoint to the mission. The full transcript remains visible; subsequent requests use fresh prompt context + latest checkpoint + retained messages. Repeated compaction updates the prior checkpoint. Failure, truncation, tool-call attempts, or Esc leave the previous context active |
 | Entry | `lunar` always opens the TUI. No print mode in v0 |
 | Providers in source | None hardcoded. Unconfigured is a valid first run |
 
@@ -172,7 +172,7 @@ Transcript scroll: PageUp / PageDown, mouse wheel, Ctrl+Home / Ctrl+End to top /
 - Missions: `/new` `/resume` `/name` `/mission`, `-c`
 - Token stats + refuse submit when last prompt ≥ window
 - Global/project `AGENTS.md`, CWD `CONTEXT.md`, and merged global/project skill summaries as a leading user message, snapshotted per user turn
-- Commands that exist: `/quit` `/q` `/help` `/new` `/resume` `/model` `/thinking` `/login` `/logout` `/name` `/mission` `/context`. `/context` opens a component summary of the live preamble and current history, with count and estimated-token breakdowns for user messages, assistant messages, tool calls, and tool results, plus a preamble + history total; `/context raw` shows their full contents, including tool calls and results. Both use a pager: PageUp/PageDown, j/k, wheel, and Ctrl+Home/End scroll, while Esc or q closes it
+- Commands that exist: `/quit` `/q` `/help` `/new` `/resume` `/model` `/thinking` `/login` `/logout` `/name` `/mission` `/context` `/compact`. `/compact [instructions]` manually summarizes older context with the live model and keeps about 20k recent estimated tokens verbatim; no automatic compaction. `/context` opens a component summary of the live preamble and current history, with count and estimated-token breakdowns for user messages, assistant messages, tool calls, and tool results, plus a preamble + history total; `/context raw` shows their full contents, including tool calls and results. Both use a pager: PageUp/PageDown, j/k, wheel, and Ctrl+Home/End scroll, while Esc or q closes it
 - Lua 5.5 embed; user `~/.lunar/control/init.lua` returns `{ models, providers, defaults }`
 - Thinking levels: each model supplies its ordered values and default; `/thinking` only accepts and displays those values; Completions and Responses wire mappings; live level in footer
 
@@ -182,7 +182,6 @@ Transcript scroll: PageUp / PageDown, mouse wheel, Ctrl+Home / Ctrl+End to top /
 - `/reload` `/trust`
 - Messages API (catalog accepts `api`; Completions and Responses send)
 - Cost in the footer, git branch, `$` prices
-- `/compact`
 
 ## Slots (foundation, Rust-filled)
 
@@ -197,8 +196,7 @@ Package manager, print/RPC/SDK, Pi session compatibility, provider zoo, themes, 
 ## Next slices (recommended order)
 
 1. Messages, if you actually use a Messages-only id
-2. Dumb `/compact` after the window hurts
-3. Walk-up context
+2. Walk-up context
 
 ## Layout in the repo
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -245,6 +245,8 @@ pub(crate) fn new_mission(app: &mut App) {
         return;
     }
     app.messages.clear();
+    app.compaction = None;
+    app.compacting = None;
     app.thinking_override = None;
     app.config = app.startup_config.clone();
     invalidate_paint(app);
@@ -367,6 +369,14 @@ pub(crate) fn load_mission(app: &mut App, path: &std::path::Path) {
             app.thinking_override = None;
             app.config = app.startup_config.clone();
             app.messages = loaded.messages;
+            app.compaction =
+                loaded
+                    .compaction
+                    .map(|(summary, first_kept)| crate::app::Compaction {
+                        summary,
+                        first_kept,
+                    });
+            app.compacting = None;
             app.mission = Some(loaded.mission);
             invalidate_paint(app);
             app.usage = loaded.usage;

--- a/src/app.rs
+++ b/src/app.rs
@@ -24,6 +24,8 @@ pub(crate) struct App {
     pub(crate) usage: Usage,
     pub(crate) last_prompt: u32,
     pub(crate) preamble: Option<String>,
+    pub(crate) compaction: Option<Compaction>,
+    pub(crate) compacting: Option<PendingCompaction>,
     pub(crate) mission: Option<mission::Mission>,
     pub(crate) mode: Mode,
     pub(crate) complete_sel: usize,
@@ -44,6 +46,18 @@ pub(crate) struct App {
     pub(crate) auth_cancel: Option<Arc<AtomicBool>>,
     pub(crate) auth_prompt: Option<AuthPrompt>,
     pub(crate) auth_brand: Option<&'static str>,
+}
+
+pub(crate) struct Compaction {
+    pub(crate) summary: String,
+    pub(crate) first_kept: usize,
+}
+
+pub(crate) struct PendingCompaction {
+    pub(crate) first_kept: usize,
+    pub(crate) tokens_before: u32,
+    pub(crate) text: String,
+    pub(crate) usage: Usage,
 }
 
 pub(crate) struct HistorySearch {
@@ -130,6 +144,8 @@ impl App {
             usage: Usage::default(),
             last_prompt: 0,
             preamble: None,
+            compaction: None,
+            compacting: None,
             mission: None,
             mode: Mode::Chat,
             complete_sel: 0,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -8,6 +8,10 @@ pub struct Command {
 /// Shown in `/` completion and `/help`. `/q` stays a hidden alias of quit.
 pub const COMMANDS: &[Command] = &[
     Command {
+        name: "compact",
+        description: "summarize old context; optional focus instructions",
+    },
+    Command {
         name: "config",
         description: "edit and reload init.lua",
     },
@@ -128,7 +132,7 @@ mod tests {
     fn slash_lists_all() {
         let found = matches("/");
         assert_eq!(found.len(), COMMANDS.len());
-        assert_eq!(found[0].name, "config");
+        assert_eq!(found[0].name, "compact");
     }
 
     #[test]

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -1,0 +1,223 @@
+//! Pi-style manual context compaction.
+
+use std::fmt::Write as _;
+
+use crate::app::{Message, Role};
+
+pub(crate) const KEEP_RECENT_TOKENS: usize = 20_000;
+const TOOL_RESULT_MAX_CHARS: usize = 2_000;
+
+pub(crate) struct Preparation {
+    pub(crate) prompt: String,
+    pub(crate) first_kept: usize,
+    pub(crate) tokens_before: u32,
+}
+
+pub(crate) fn prepare(
+    messages: &[Message],
+    boundary_start: usize,
+    previous_summary: Option<&str>,
+    instructions: Option<&str>,
+) -> Option<Preparation> {
+    if boundary_start >= messages.len() {
+        return None;
+    }
+    let first_kept = cut_point(messages, boundary_start, KEEP_RECENT_TOKENS);
+    if first_kept <= boundary_start {
+        return None;
+    }
+
+    let conversation = serialize(&messages[boundary_start..first_kept]);
+    if conversation.is_empty() {
+        return None;
+    }
+    let task = if previous_summary.is_some() {
+        UPDATE_PROMPT
+    } else {
+        INITIAL_PROMPT
+    };
+    let mut prompt = format!("<conversation>\n{conversation}\n</conversation>\n\n");
+    if let Some(summary) = previous_summary {
+        let _ = write!(
+            prompt,
+            "<previous-summary>\n{summary}\n</previous-summary>\n\n"
+        );
+    }
+    prompt.push_str(task);
+    if let Some(instructions) = instructions.filter(|text| !text.trim().is_empty()) {
+        let _ = write!(prompt, "\n\nAdditional focus: {}", instructions.trim());
+    }
+
+    let tokens_before = estimate_slice(&messages[boundary_start..])
+        + previous_summary.map(estimate_text).unwrap_or(0);
+    Some(Preparation {
+        prompt,
+        first_kept,
+        tokens_before: tokens_before.min(u32::MAX as usize) as u32,
+    })
+}
+
+fn cut_point(messages: &[Message], start: usize, keep_tokens: usize) -> usize {
+    let valid: Vec<usize> = (start..messages.len())
+        .filter(|&i| !matches!(messages[i].role, Role::Tool))
+        .collect();
+    let Some(&first) = valid.first() else {
+        return start;
+    };
+    let mut accumulated = 0;
+    let mut cut = first;
+    for i in (start..messages.len()).rev() {
+        accumulated += estimate_message(&messages[i]);
+        if accumulated >= keep_tokens {
+            cut = valid
+                .iter()
+                .copied()
+                .find(|&candidate| candidate >= i)
+                .unwrap_or(first);
+            break;
+        }
+    }
+    cut
+}
+
+pub(crate) fn estimate_context(summary: &str, messages: &[Message]) -> u32 {
+    (estimate_text(summary) + estimate_slice(messages)).min(u32::MAX as usize) as u32
+}
+
+fn estimate_slice(messages: &[Message]) -> usize {
+    messages.iter().map(estimate_message).sum()
+}
+
+fn estimate_message(message: &Message) -> usize {
+    let chars = message.text.chars().count()
+        + message
+            .tool_calls
+            .iter()
+            .map(|call| call.name.chars().count() + call.arguments.chars().count())
+            .sum::<usize>();
+    chars.div_ceil(4) + 4
+}
+
+fn estimate_text(text: &str) -> usize {
+    text.chars().count().div_ceil(4)
+}
+
+fn serialize(messages: &[Message]) -> String {
+    let mut parts = Vec::new();
+    for message in messages {
+        match message.role {
+            Role::User => parts.push(format!("[User]: {}", message.text)),
+            Role::Assistant => {
+                if !message.text.is_empty() {
+                    parts.push(format!("[Assistant]: {}", message.text));
+                }
+                if !message.tool_calls.is_empty() {
+                    let calls = message
+                        .tool_calls
+                        .iter()
+                        .map(|call| format!("{}({})", call.name, call.arguments))
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    parts.push(format!("[Assistant tool calls]: {calls}"));
+                }
+            }
+            Role::Tool => {
+                let text = truncate_chars(&message.text, TOOL_RESULT_MAX_CHARS);
+                parts.push(format!("[Tool result: {}]: {text}", message.tool_title));
+            }
+        }
+    }
+    parts.join("\n\n")
+}
+
+fn truncate_chars(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let kept: String = text.chars().take(max).collect();
+    format!("{kept}\n\n[... tool result truncated]")
+}
+
+const INITIAL_PROMPT: &str = r#"Create a structured context checkpoint summary that another LLM will use to continue the work.
+Do not continue the conversation or answer questions from it. Output only this format:
+
+## Goal
+[What the user is trying to accomplish]
+
+## Constraints & Preferences
+- [Requirements and preferences, or "(none)"]
+
+## Progress
+### Done
+- [x] [Completed work]
+### In Progress
+- [ ] [Current work]
+### Blocked
+- [Blockers, if any]
+
+## Key Decisions
+- **[Decision]**: [Rationale]
+
+## Next Steps
+1. [What should happen next]
+
+## Critical Context
+- [Details needed to continue, or "(none)"]
+
+Keep each section concise. Preserve exact file paths, function names, commands, and error messages."#;
+
+const UPDATE_PROMPT: &str = r#"Update the existing structured summary with the new conversation messages.
+Do not continue the conversation or answer questions from it. Output only the same structured format.
+Preserve still-relevant goals, constraints, decisions, exact file paths, function names, commands, and error messages. Add new progress and context, move completed work to Done, remove resolved blockers, and update Next Steps. Keep each section concise."#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::ToolCall;
+
+    #[test]
+    fn keeps_recent_messages_and_never_starts_at_a_tool_result() {
+        let mut messages = vec![Message::user("old".repeat(10_000))];
+        let mut assistant = Message::assistant();
+        assistant.tool_calls.push(ToolCall {
+            id: "1".into(),
+            name: "read".into(),
+            arguments: "{}".into(),
+        });
+        messages.push(assistant);
+        messages.push(Message::tool(
+            "1".into(),
+            "read".into(),
+            "x".repeat(100_000),
+        ));
+        messages.push(Message::user("recent".into()));
+
+        let prepared = prepare(&messages, 0, None, None).unwrap();
+        assert_eq!(prepared.first_kept, 3);
+        assert!(!matches!(messages[prepared.first_kept].role, Role::Tool));
+        assert!(prepared.prompt.contains("[User]: old"));
+    }
+
+    #[test]
+    fn repeated_compaction_updates_previous_summary() {
+        let messages = vec![
+            Message::user("boundary".into()),
+            Message::user("older".into()),
+            Message::user("middle".repeat(20_000)),
+            Message::user("new".repeat(20_000)),
+        ];
+        let prepared = prepare(
+            &messages,
+            1,
+            Some("previous checkpoint"),
+            Some("focus on tests"),
+        )
+        .unwrap();
+        assert!(
+            prepared
+                .prompt
+                .contains("<previous-summary>\nprevious checkpoint")
+        );
+        assert!(prepared.prompt.contains("Additional focus: focus on tests"));
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,13 +7,25 @@ use crate::prompt;
 use crate::protocol::ChatMessage;
 
 /// Build the semantic message history sent to either model protocol.
-pub(crate) fn history(preamble: Option<&str>, messages: &[Message]) -> Vec<ChatMessage> {
+pub(crate) fn history(
+    preamble: Option<&str>,
+    compaction: Option<(&str, usize)>,
+    messages: &[Message],
+) -> Vec<ChatMessage> {
     let mut out = Vec::new();
     if let Some(text) = preamble {
         out.push(ChatMessage::User(text.to_string()));
     }
+    let start = if let Some((summary, first_kept)) = compaction {
+        out.push(ChatMessage::User(format!(
+            "The conversation before this point was compacted into this checkpoint:\n\n{summary}"
+        )));
+        first_kept.min(messages.len())
+    } else {
+        0
+    };
     out.extend(
-        messages
+        messages[start..]
             .iter()
             .filter(|m| {
                 !m.text.is_empty() || matches!(m.role, Role::User) || !m.tool_calls.is_empty()
@@ -34,7 +46,7 @@ pub(crate) fn history(preamble: Option<&str>, messages: &[Message]) -> Vec<ChatM
 }
 
 /// Summarize the context known before the next user message.
-pub(crate) fn summary(messages: &[Message]) -> String {
+pub(crate) fn summary(messages: &[Message], compaction: Option<(&str, usize)>) -> String {
     let (mut out, preamble_tokens) = prompt::summary();
     let mut users = 0;
     let mut assistants = 0;
@@ -44,7 +56,11 @@ pub(crate) fn summary(messages: &[Message]) -> String {
     let mut assistant_chars = 0;
     let mut tool_call_chars = 0;
     let mut tool_result_chars = 0;
-    for message in messages {
+    let start = compaction
+        .map(|(_, first_kept)| first_kept)
+        .unwrap_or(0)
+        .min(messages.len());
+    for message in &messages[start..] {
         match message.role {
             Role::User => {
                 users += 1;
@@ -71,19 +87,24 @@ pub(crate) fn summary(messages: &[Message]) -> String {
     let assistant_tokens = assistant_chars.div_ceil(4);
     let tool_call_tokens = tool_call_chars.div_ceil(4);
     let tool_result_tokens = tool_result_chars.div_ceil(4);
-    let total_tokens = user_tokens + assistant_tokens + tool_call_tokens + tool_result_tokens;
+    let summary_tokens = compaction
+        .map(|(summary, _)| summary.chars().count().div_ceil(4))
+        .unwrap_or(0);
+    let total_tokens =
+        summary_tokens + user_tokens + assistant_tokens + tool_call_tokens + tool_result_tokens;
     let _ = write!(
         out,
-        "\n\nhistory  ~{total_tokens} tokens\n  user messages      {users}  ~{user_tokens} tokens\n  assistant messages {assistants}  ~{assistant_tokens} tokens\n  tool calls         {tool_calls}  ~{tool_call_tokens} tokens\n  tool results       {tool_results}  ~{tool_result_tokens} tokens\n\ntotal  ~{} tokens",
+        "\n\ncheckpoint  ~{summary_tokens} tokens\nhistory  ~{} tokens\n  user messages      {users}  ~{user_tokens} tokens\n  assistant messages {assistants}  ~{assistant_tokens} tokens\n  tool calls         {tool_calls}  ~{tool_call_tokens} tokens\n  tool results       {tool_results}  ~{tool_result_tokens} tokens\n\ntotal  ~{} tokens",
+        total_tokens - summary_tokens,
         preamble_tokens + total_tokens
     );
     out
 }
 
 /// Display the complete context known before the next user message.
-pub(crate) fn raw(messages: &[Message]) -> String {
+pub(crate) fn raw(messages: &[Message], compaction: Option<(&str, usize)>) -> String {
     let preamble = prompt::preamble();
-    let history = history(preamble.as_deref(), messages);
+    let history = history(preamble.as_deref(), compaction, messages);
     format_history(history)
 }
 
@@ -142,7 +163,7 @@ mod tests {
             Message::tool("call-1".into(), "read".into(), "secret result".into()),
         ];
 
-        let summary = summary(&messages);
+        let summary = summary(&messages, None);
         assert!(summary.contains("history  ~"));
         assert!(summary.contains("total  ~"));
         assert!(summary.contains("user messages      1  ~4 tokens"));
@@ -196,7 +217,7 @@ mod tests {
             Message::tool("call-1".into(), "read".into(), "contents".into()),
         ];
 
-        let history = history(Some("instructions"), &messages);
+        let history = history(Some("instructions"), None, &messages);
         assert_eq!(history.len(), 4);
         assert!(matches!(&history[0], ChatMessage::User(text) if text == "instructions"));
         assert!(matches!(&history[1], ChatMessage::User(text) if text == "question"));

--- a/src/event.rs
+++ b/src/event.rs
@@ -19,7 +19,7 @@ use crate::input::{
     on_search_key, prev_char, reset_history_navigation, start_search, word_left, word_right,
 };
 use crate::transcript::{jump_to_tail, on_mouse, page_delta, scroll_by, scroll_home};
-use crate::turn::{abort_turn, drain_stream, send_prompt};
+use crate::turn::{abort_turn, drain_stream, send_prompt, start_compaction};
 use crate::view::draw;
 
 const RESUME_GAP: Duration = Duration::from_secs(30);
@@ -477,11 +477,25 @@ pub(crate) fn submit(app: &mut App) {
             }
         }
         "/mission" => show_mission(app),
+        "/compact" => start_compaction(app, None),
+        cmd if let Some(instructions) = cmd.strip_prefix("/compact ") => {
+            start_compaction(app, Some(instructions))
+        }
         "/context" | "/context raw" => {
             let text = if line == "/context raw" {
-                crate::context::raw(&app.messages)
+                crate::context::raw(
+                    &app.messages,
+                    app.compaction
+                        .as_ref()
+                        .map(|compact| (compact.summary.as_str(), compact.first_kept)),
+                )
             } else {
-                crate::context::summary(&app.messages)
+                crate::context::summary(
+                    &app.messages,
+                    app.compaction
+                        .as_ref()
+                        .map(|compact| (compact.summary.as_str(), compact.first_kept)),
+                )
             };
             app.mode = Mode::Context { text, scroll: 0 };
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod app;
 mod auth;
 mod cli;
 mod commands;
+mod compact;
 mod context;
 mod debug;
 mod event;
@@ -125,6 +126,8 @@ mod tests {
             usage: Usage::default(),
             last_prompt: 0,
             preamble: None,
+            compaction: None,
+            compacting: None,
             mission: None,
             mode: Mode::Chat,
             complete_sel: 0,

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -142,6 +142,7 @@ pub struct Loaded {
     pub thinking: Option<String>,
     pub usage: Usage,
     pub last_prompt: u32,
+    pub compaction: Option<(String, usize)>,
 }
 
 pub fn create(name: &str) -> io::Result<Mission> {
@@ -272,6 +273,7 @@ pub fn load(path: &Path) -> io::Result<Loaded> {
     let mut thinking = None;
     let mut usage = Usage::default();
     let mut last_prompt = 0;
+    let mut compaction = None;
     for line in BufReader::new(file).lines() {
         let line = line?;
         if line.trim().is_empty() {
@@ -317,6 +319,21 @@ pub fn load(path: &Path) -> io::Result<Loaded> {
                 };
                 usage.add(item);
                 last_prompt = item.prompt();
+            }
+            Some("compaction") => {
+                if let (Some(summary), Some(first_kept)) = (
+                    value.get("summary").and_then(Value::as_str),
+                    value.get("first_kept").and_then(Value::as_u64),
+                ) {
+                    compaction = Some((summary.to_string(), first_kept as usize));
+                    if let Some(tokens_after) = value
+                        .get("tokens_after")
+                        .and_then(Value::as_u64)
+                        .and_then(|tokens| tokens.try_into().ok())
+                    {
+                        last_prompt = tokens_after;
+                    }
+                }
             }
             Some("user") => {
                 if let Some(text) = value.get("text").and_then(Value::as_str) {
@@ -366,6 +383,7 @@ pub fn load(path: &Path) -> io::Result<Loaded> {
         thinking,
         usage,
         last_prompt,
+        compaction,
     })
 }
 
@@ -384,6 +402,21 @@ pub fn usage_line(usage: Usage) -> Value {
         "output": usage.output,
         "cache_read": usage.cache_read,
         "cache_write": usage.cache_write,
+    })
+}
+
+pub fn compaction_line(
+    summary: &str,
+    first_kept: usize,
+    tokens_before: u32,
+    tokens_after: u32,
+) -> Value {
+    json!({
+        "type": "compaction",
+        "summary": summary,
+        "first_kept": first_kept,
+        "tokens_before": tokens_before,
+        "tokens_after": tokens_after,
     })
 }
 

--- a/src/protocol/completions.rs
+++ b/src/protocol/completions.rs
@@ -48,9 +48,10 @@ pub(super) fn stream(
     messages: Vec<ChatMessage>,
     cancel: Arc<AtomicBool>,
     tx: &Sender<StreamEvent>,
+    tools: bool,
 ) -> Result<(), String> {
     let url = format!("{}/chat/completions", cfg.base_url.trim_end_matches('/'));
-    let body = body(&cfg, &messages);
+    let body = body(&cfg, &messages, tools);
 
     let response = post_retry(&url, &cfg.api_key, &body, &cancel, None, None)?;
 
@@ -161,22 +162,35 @@ pub(super) fn stream(
             call
         })
         .collect();
-    if calls.is_empty() {
-        let _ = tx.send(StreamEvent::Done);
+    if !tools && (truncated || !calls.is_empty()) {
+        let message = if truncated {
+            "generation hit the token cap"
+        } else {
+            "model attempted to call a tool"
+        };
+        let _ = tx.send(StreamEvent::Failed(message.into()));
+    } else if calls.is_empty() {
+        let _ = tx.send(if tools {
+            StreamEvent::Done
+        } else {
+            StreamEvent::CompactDone
+        });
     } else {
         let _ = tx.send(StreamEvent::Tools { calls, truncated });
     }
     Ok(())
 }
 
-fn body(cfg: &Config, messages: &[ChatMessage]) -> String {
+fn body(cfg: &Config, messages: &[ChatMessage], include_tools: bool) -> String {
     let mut body = json!({
         "model": cfg.model,
         "stream": true,
         "stream_options": { "include_usage": true },
-        "tools": tools::completions_definitions(),
         "messages": messages.iter().map(ChatMessage::to_completions).collect::<Vec<_>>(),
     });
+    if include_tools {
+        body["tools"] = tools::completions_definitions();
+    }
     if is_openai_url(&cfg.base_url) {
         body["max_completion_tokens"] = json!(MAX_TOKENS);
     } else {
@@ -219,7 +233,7 @@ mod tests {
             thinking: "off".into(),
             thinking_levels: vec!["off".into()],
         };
-        let body: Value = serde_json::from_str(&body(&cfg, &[])).unwrap();
+        let body: Value = serde_json::from_str(&body(&cfg, &[], true)).unwrap();
         assert_eq!(body["max_tokens"], MAX_TOKENS);
         assert_eq!(body["stream"], true);
         assert_eq!(body["model"], "grok-4.6");
@@ -238,7 +252,7 @@ mod tests {
             thinking: "max".into(),
             thinking_levels: vec!["low".into(), "high".into(), "max".into()],
         };
-        let parsed: Value = serde_json::from_str(&body(&cfg, &[])).unwrap();
+        let parsed: Value = serde_json::from_str(&body(&cfg, &[], true)).unwrap();
         assert_eq!(parsed["reasoning_effort"], "max");
     }
 
@@ -255,7 +269,7 @@ mod tests {
             thinking: "off".into(),
             thinking_levels: vec!["off".into()],
         };
-        let parsed: Value = serde_json::from_str(&body(&cfg, &[])).unwrap();
+        let parsed: Value = serde_json::from_str(&body(&cfg, &[], true)).unwrap();
         assert_eq!(parsed["max_completion_tokens"], MAX_TOKENS);
         assert!(parsed.get("reasoning_effort").is_none());
         assert!(parsed.get("max_tokens").is_none());

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -129,6 +129,7 @@ pub enum StreamEvent {
     },
     ToolResults(Vec<ToolResult>),
     Done,
+    CompactDone,
     Failed(String),
 }
 
@@ -138,6 +139,7 @@ pub fn stream(
     cancel: Arc<AtomicBool>,
     tx: Sender<StreamEvent>,
     cache_key: Option<String>,
+    tools: bool,
 ) {
     if let Some(provider) = cfg.auth_provider.as_deref() {
         match crate::auth::resolve(provider) {
@@ -149,8 +151,8 @@ pub fn stream(
         }
     }
     let result = match cfg.api {
-        Api::Completions => completions::stream(cfg, messages, cancel, &tx),
-        Api::Responses => responses::stream(cfg, messages, cancel, &tx, cache_key),
+        Api::Completions => completions::stream(cfg, messages, cancel, &tx, tools),
+        Api::Responses => responses::stream(cfg, messages, cancel, &tx, cache_key, tools),
         Api::Messages => Err(format!("{} uses messages, not implemented", cfg.model)),
     };
     if let Err(err) = result {

--- a/src/protocol/responses.rs
+++ b/src/protocol/responses.rs
@@ -74,13 +74,14 @@ pub(super) fn stream(
     cancel: Arc<AtomicBool>,
     tx: &Sender<StreamEvent>,
     cache_key: Option<String>,
+    tools: bool,
 ) -> Result<(), String> {
     let url = responses_url(&cfg);
     let cache_key = cache_key
         .as_deref()
         .map(clamp_cache_key)
         .filter(|key| !key.is_empty());
-    let body = body(&cfg, &messages, cache_key.as_deref());
+    let body = body(&cfg, &messages, cache_key.as_deref(), tools);
     let account = if cfg.auth_provider.as_deref() == Some("openai") {
         Some(crate::auth::chatgpt_account_id(&cfg.api_key)?)
     } else {
@@ -145,8 +146,19 @@ pub(super) fn stream(
             call
         })
         .collect();
-    if calls.is_empty() {
-        let _ = tx.send(StreamEvent::Done);
+    if !tools && (truncated || !calls.is_empty()) {
+        let message = if truncated {
+            "generation hit the token cap"
+        } else {
+            "model attempted to call a tool"
+        };
+        let _ = tx.send(StreamEvent::Failed(message.into()));
+    } else if calls.is_empty() {
+        let _ = tx.send(if tools {
+            StreamEvent::Done
+        } else {
+            StreamEvent::CompactDone
+        });
     } else {
         let _ = tx.send(StreamEvent::Tools { calls, truncated });
     }
@@ -166,7 +178,12 @@ fn clamp_cache_key(key: &str) -> String {
     key.chars().take(64).collect()
 }
 
-fn body(cfg: &Config, messages: &[ChatMessage], cache_key: Option<&str>) -> String {
+fn body(
+    cfg: &Config,
+    messages: &[ChatMessage],
+    cache_key: Option<&str>,
+    include_tools: bool,
+) -> String {
     let mut value = json!({
         "model": cfg.model,
         "stream": true,
@@ -179,9 +196,11 @@ fn body(cfg: &Config, messages: &[ChatMessage], cache_key: Option<&str>) -> Stri
                 json!(&cfg.thinking)
             },
         },
-        "tools": tools::responses_definitions(),
         "input": flatten_input(messages),
     });
+    if include_tools {
+        value["tools"] = tools::responses_definitions();
+    }
     if cfg.thinking == "off" {
         value["reasoning"].as_object_mut().unwrap().remove("effort");
     }
@@ -368,7 +387,7 @@ mod tests {
         let mut cfg = sample_cfg();
         cfg.thinking = "max".into();
         cfg.thinking_levels = vec!["low".into(), "high".into(), "max".into()];
-        let parsed: Value = serde_json::from_str(&body(&cfg, &[], None)).unwrap();
+        let parsed: Value = serde_json::from_str(&body(&cfg, &[], None, true)).unwrap();
         assert_eq!(parsed["reasoning"]["effort"], "max");
     }
 
@@ -390,7 +409,8 @@ mod tests {
             },
         ];
         let parsed: Value =
-            serde_json::from_str(&body(&sample_cfg(), &messages, Some("2026-08-22-1"))).unwrap();
+            serde_json::from_str(&body(&sample_cfg(), &messages, Some("2026-08-22-1"), true))
+                .unwrap();
         assert_eq!(parsed["model"], "gpt-5");
         assert_eq!(parsed["stream"], true);
         assert_eq!(parsed["store"], false);
@@ -420,13 +440,15 @@ mod tests {
     #[test]
     fn body_omits_empty_cache_key_and_clamps_long_ones() {
         let messages = vec![ChatMessage::User("hi".into())];
-        let none: Value = serde_json::from_str(&body(&sample_cfg(), &messages, None)).unwrap();
+        let none: Value =
+            serde_json::from_str(&body(&sample_cfg(), &messages, None, true)).unwrap();
         assert!(none.get("prompt_cache_key").is_none());
         let long = "m".repeat(80);
         let clamped: Value = serde_json::from_str(&body(
             &sample_cfg(),
             &messages,
             Some(&clamp_cache_key(&long)),
+            true,
         ))
         .unwrap();
         assert_eq!(

--- a/src/turn.rs
+++ b/src/turn.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, TryRecvError};
 
 use crate::app::{App, Message, Role};
-use crate::protocol::{self, Config, StreamEvent, ToolCall, ToolResult};
+use crate::protocol::{self, Config, StreamEvent, ToolCall, ToolResult, Usage};
 use crate::transcript::jump_to_tail;
 use crate::{mission, prompt, tools};
 
@@ -19,26 +19,33 @@ pub(crate) fn drain_stream(app: &mut App) {
     loop {
         match rx.try_recv() {
             Ok(StreamEvent::Delta(text)) => {
-                if let Some(last) = app.messages.last_mut()
+                if let Some(compacting) = &mut app.compacting {
+                    compacting.text.push_str(&text);
+                } else if let Some(last) = app.messages.last_mut()
                     && matches!(last.role, Role::Assistant)
                 {
                     last.text.push_str(&text);
                 }
             }
             Ok(StreamEvent::Think(text)) => {
-                if let Some(last) = app.messages.last_mut()
+                if app.compacting.is_none()
+                    && let Some(last) = app.messages.last_mut()
                     && matches!(last.role, Role::Assistant)
                 {
                     last.thinking.push_str(&text);
                 }
             }
             Ok(StreamEvent::Usage(usage)) => {
-                app.usage.add(usage);
-                app.last_prompt = usage.prompt();
-                if let Some(m) = &app.mission
-                    && let Err(err) = mission::append(m, &mission::usage_line(usage))
-                {
-                    app.notice = Some(format!("mission: {err}"));
+                if let Some(compacting) = &mut app.compacting {
+                    compacting.usage.add(usage);
+                } else {
+                    app.usage.add(usage);
+                    app.last_prompt = usage.prompt();
+                    if let Some(m) = &app.mission
+                        && let Err(err) = mission::append(m, &mission::usage_line(usage))
+                    {
+                        app.notice = Some(format!("mission: {err}"));
+                    }
                 }
             }
             Ok(other) => {
@@ -61,6 +68,7 @@ pub(crate) fn finish_stream(app: &mut App, end: StreamEvent) {
     match end {
         StreamEvent::Tools { calls, truncated } => begin_tools(app, calls, truncated),
         StreamEvent::ToolResults(results) => apply_tool_results(app, results),
+        StreamEvent::CompactDone => finish_compaction(app),
         StreamEvent::Done => {
             persist_last_assistant(app);
             app.stream_rx = None;
@@ -68,6 +76,12 @@ pub(crate) fn finish_stream(app: &mut App, end: StreamEvent) {
             pop_empty_assistant(app);
         }
         StreamEvent::Failed(err) => {
+            if app.compacting.take().is_some() {
+                app.stream_rx = None;
+                app.cancel = None;
+                app.notice = Some(format!("compaction: {err}"));
+                return;
+            }
             finish_failed(app, &err);
             app.stream_rx = None;
             app.cancel = None;
@@ -81,6 +95,12 @@ pub(crate) fn finish_stream(app: &mut App, end: StreamEvent) {
 pub(crate) fn abort_turn(app: &mut App) {
     if let Some(flag) = &app.cancel {
         flag.store(true, Ordering::Relaxed);
+    }
+    if app.compacting.take().is_some() {
+        app.stream_rx = None;
+        app.cancel = None;
+        app.notice = Some("aborted".into());
+        return;
     }
     finish_failed(app, "aborted");
     app.stream_rx = None;
@@ -270,6 +290,94 @@ pub(crate) fn persist_last_assistant(app: &mut App) {
     persist_value(app, &mission::assistant_line(&last.text, &last.tool_calls));
 }
 
+pub(crate) fn start_compaction(app: &mut App, instructions: Option<&str>) {
+    let Some(cfg) = app.config.clone() else {
+        app.notice = Some("no model configured".into());
+        return;
+    };
+    if app.messages.is_empty() {
+        app.notice = Some("nothing to compact".into());
+        return;
+    }
+    let boundary = app
+        .compaction
+        .as_ref()
+        .map(|compact| compact.first_kept)
+        .unwrap_or(0);
+    let previous = app
+        .compaction
+        .as_ref()
+        .map(|compact| compact.summary.as_str());
+    let Some(prepared) = crate::compact::prepare(&app.messages, boundary, previous, instructions)
+    else {
+        app.notice = Some("nothing old enough to compact".into());
+        return;
+    };
+
+    let cancel = Arc::new(AtomicBool::new(false));
+    let (tx, rx) = mpsc::channel();
+    app.compacting = Some(crate::app::PendingCompaction {
+        first_kept: prepared.first_kept,
+        tokens_before: prepared.tokens_before,
+        text: String::new(),
+        usage: Usage::default(),
+    });
+    app.cancel = Some(cancel.clone());
+    app.stream_rx = Some(rx);
+    app.notice = None;
+    let cache_key = app.mission.as_ref().map(|mission| mission.id.clone());
+    std::thread::spawn(move || {
+        protocol::stream(
+            cfg,
+            vec![crate::protocol::ChatMessage::User(prepared.prompt)],
+            cancel,
+            tx,
+            cache_key,
+            false,
+        )
+    });
+}
+
+fn finish_compaction(app: &mut App) {
+    let Some(done) = app.compacting.take() else {
+        return;
+    };
+    app.stream_rx = None;
+    app.cancel = None;
+    if done.text.trim().is_empty() {
+        app.notice = Some("compaction: model returned an empty summary".into());
+        return;
+    }
+    let summary = done.text.trim().to_string();
+    let tokens_after = crate::compact::estimate_context(&summary, &app.messages[done.first_kept..]);
+    if done.usage.prompt() > 0 || done.usage.output > 0 {
+        app.usage.add(done.usage);
+        if let Some(mission) = &app.mission
+            && let Err(err) = mission::append(mission, &mission::usage_line(done.usage))
+        {
+            app.notice = Some(format!("mission: {err}"));
+            return;
+        }
+    }
+    let Some(mission) = &app.mission else {
+        app.notice = Some("compaction: no mission".into());
+        return;
+    };
+    if let Err(err) = mission::append(
+        mission,
+        &mission::compaction_line(&summary, done.first_kept, done.tokens_before, tokens_after),
+    ) {
+        app.notice = Some(format!("mission: {err}"));
+        return;
+    }
+    app.last_prompt = tokens_after;
+    app.compaction = Some(crate::app::Compaction {
+        summary,
+        first_kept: done.first_kept,
+    });
+    app.notice = Some("context compacted".into());
+}
+
 pub(crate) fn send_prompt(app: &mut App, line: String) {
     if app.config.is_none() {
         app.notice = Some("no model configured".into());
@@ -301,9 +409,15 @@ pub(crate) fn continue_turn(app: &mut App) {
         return;
     };
     app.messages.push(Message::assistant());
-    let history = crate::context::history(app.preamble.as_deref(), &app.messages);
+    let history = crate::context::history(
+        app.preamble.as_deref(),
+        app.compaction
+            .as_ref()
+            .map(|compact| (compact.summary.as_str(), compact.first_kept)),
+        &app.messages,
+    );
     let (tx, rx) = mpsc::channel();
     app.stream_rx = Some(rx);
     let cache_key = app.mission.as_ref().map(|m| m.id.clone());
-    std::thread::spawn(move || protocol::stream(cfg, history, cancel, tx, cache_key));
+    std::thread::spawn(move || protocol::stream(cfg, history, cancel, tx, cache_key, true));
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -145,7 +145,9 @@ pub(crate) fn draw(frame: &mut Frame, app: &mut App) {
 pub(crate) const SPINNER: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 pub(crate) fn working_text(app: &App) -> &'static str {
-    if matches!(
+    if app.compacting.is_some() {
+        " Compacting..."
+    } else if matches!(
         app.messages.last(),
         Some(Message {
             role: Role::Assistant,


### PR DESCRIPTION
## Summary

- add `/compact [instructions]` using the live model without tools
- preserve roughly 20k recent estimated tokens and replace older model-visible history with an append-only checkpoint
- restore checkpoints on mission resume and reflect compacted context in `/context`
- reject failed, truncated, aborted, empty, or tool-calling summaries without changing active context

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (158 passed)
- `git diff --check`

🤖 Developed with [Lunar](https://github.com/gszr/lunar) 🌘
